### PR TITLE
GEN-PART-PG-BRIDGE-003: add governed Postgres bridge worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,11 @@
 
 SUPABASE_URL=https://<project-ref>.supabase.co
 SUPABASE_PUBLISHABLE_KEY=sb_publishable_<replace-me>
+
+# GEN-PART-PG-BRIDGE-003
+# Use pooled Neon connection strings and store the real values only in the deployment secret store.
+CWR_REGISTRY_DATABASE_URL=postgresql://<user>:<password>@<cwr-host>/<database>?sslmode=require
+VSR_PUBLIC_DATABASE_URL=postgresql://<user>:<password>@<vsr-host>/<database>?sslmode=require
+REGISTRY_BRIDGE_SECRET=<replace-with-long-random-secret>
+# Vercel Cron may use CRON_SECRET instead of REGISTRY_BRIDGE_SECRET.
+CRON_SECRET=<optional-replace-with-long-random-secret>

--- a/.github/workflows/bridge-test.yml
+++ b/.github/workflows/bridge-test.yml
@@ -1,0 +1,27 @@
+name: bridge-test
+
+on:
+  pull_request:
+    paths:
+      - 'api/registry-bridge.ts'
+      - 'api/registry-bridge.test.ts'
+      - 'package.json'
+      - '.github/workflows/bridge-test.yml'
+
+jobs:
+  bridge-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Run bridge tests
+        run: npm run test:bridge

--- a/api/registry-bridge.test.ts
+++ b/api/registry-bridge.test.ts
@@ -1,0 +1,162 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const queries = vi.hoisted(() => ({ source: [] as string[], target: [] as string[] }));
+
+vi.mock("@neondatabase/serverless", () => ({
+  neon: (url: string) => async (strings: TemplateStringsArray, ..._values: unknown[]) => {
+    const sql = strings.join("?");
+    const bucket = url === "source-db" ? queries.source : queries.target;
+    bucket.push(sql);
+
+    if (url === "source-db" && sql.includes("with candidates as")) {
+      return [
+        {
+          registry_outbox_id: "00000000-0000-0000-0000-000000000001",
+          event_reference: "EVT-001",
+          source_node_code: "CWR-REGISTRY",
+          change_code: "CHG-001",
+          event_code: "REGISTRY.TEST",
+          object_type: "participant",
+          object_code: "PART-001",
+          registry_revision_ref: "REV-001",
+          payload: { ok: true },
+          evidence_reference: null,
+          occurred_at: "2026-08-12T17:00:00.000Z",
+        },
+      ];
+    }
+
+    return [];
+  },
+}));
+
+import handler, { getBatchSize, isAuthorized } from "./registry-bridge.js";
+
+function request(overrides: Partial<IncomingMessage> = {}) {
+  return {
+    method: "GET",
+    url: "/api/registry-bridge",
+    headers: {},
+    ...overrides,
+  } as IncomingMessage;
+}
+
+function response() {
+  const headers = new Map<string, string>();
+  let body = "";
+
+  const res = {
+    statusCode: 200,
+    setHeader(name: string, value: string) {
+      headers.set(name.toLowerCase(), value);
+      return res;
+    },
+    end(chunk?: string) {
+      body = chunk ?? "";
+      return res;
+    },
+  } as unknown as ServerResponse;
+
+  return {
+    res,
+    get statusCode() {
+      return res.statusCode;
+    },
+    get body() {
+      return body;
+    },
+    header(name: string) {
+      return headers.get(name.toLowerCase());
+    },
+  };
+}
+
+const originalEnv = { ...process.env };
+
+describe("GEN-PART-PG-BRIDGE-003", () => {
+  beforeEach(() => {
+    queries.source.length = 0;
+    queries.target.length = 0;
+    process.env = { ...originalEnv };
+    delete process.env.REGISTRY_BRIDGE_SECRET;
+    delete process.env.CRON_SECRET;
+    delete process.env.CWR_REGISTRY_DATABASE_URL;
+    delete process.env.VSR_PUBLIC_DATABASE_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("bounds requested batch size", () => {
+    expect(getBatchSize(request({ url: "/api/registry-bridge?limit=250" }))).toBe(100);
+    expect(getBatchSize(request({ url: "/api/registry-bridge?limit=0" }))).toBe(1);
+    expect(getBatchSize(request({ url: "/api/registry-bridge?limit=not-a-number" }))).toBe(25);
+  });
+
+  it("requires the configured bearer secret", () => {
+    process.env.REGISTRY_BRIDGE_SECRET = "bridge-secret";
+
+    expect(isAuthorized(request({ headers: { authorization: "Bearer bridge-secret" } }))).toBe(true);
+    expect(isAuthorized(request({ headers: { authorization: "Bearer wrong" } }))).toBe(false);
+  });
+
+  it("rejects unsupported methods before any database access", async () => {
+    const output = response();
+    await handler(request({ method: "PUT" }), output.res);
+
+    expect(output.statusCode).toBe(405);
+    expect(output.header("allow")).toBe("GET, POST");
+    expect(JSON.parse(output.body)).toEqual({ ok: false, error: "method_not_allowed" });
+    expect(queries.source).toHaveLength(0);
+    expect(queries.target).toHaveLength(0);
+  });
+
+  it("returns configuration failure without touching either database", async () => {
+    process.env.REGISTRY_BRIDGE_SECRET = "bridge-secret";
+    const output = response();
+
+    await handler(
+      request({ headers: { authorization: "Bearer bridge-secret" } }),
+      output.res,
+    );
+
+    expect(output.statusCode).toBe(503);
+    expect(JSON.parse(output.body)).toMatchObject({
+      ok: false,
+      error: "bridge_not_configured",
+      missing: ["CWR_REGISTRY_DATABASE_URL", "VSR_PUBLIC_DATABASE_URL"],
+    });
+    expect(queries.source).toHaveLength(0);
+    expect(queries.target).toHaveLength(0);
+  });
+
+  it("claims before delivery and marks source delivered only after target writes", async () => {
+    process.env.REGISTRY_BRIDGE_SECRET = "bridge-secret";
+    process.env.CWR_REGISTRY_DATABASE_URL = "source-db";
+    process.env.VSR_PUBLIC_DATABASE_URL = "target-db";
+    const output = response();
+
+    await handler(
+      request({ headers: { authorization: "Bearer bridge-secret" } }),
+      output.res,
+    );
+
+    expect(output.statusCode).toBe(200);
+    expect(JSON.parse(output.body)).toMatchObject({
+      ok: true,
+      bridge: "GEN-PART-PG-BRIDGE-003",
+      source: "CWR-REGISTRY",
+      scanned: 1,
+      delivered: 1,
+      failed: 0,
+    });
+
+    expect(queries.source[0]).toContain("delivery_state = 'leased'");
+    expect(queries.target[0]).toContain("registry_inbox");
+    expect(queries.target[0]).toContain("on conflict (source_node_code, event_reference) do nothing");
+    expect(queries.target[1]).toContain("registry_sync_checkpoints");
+    expect(queries.source[1]).toContain("delivery_state = 'delivered'");
+  });
+});

--- a/api/registry-bridge.ts
+++ b/api/registry-bridge.ts
@@ -1,0 +1,185 @@
+import { neon } from "@neondatabase/serverless";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+const SOURCE_NODE_CODE = "CWR-REGISTRY";
+const DEFAULT_BATCH_SIZE = 25;
+const MAX_BATCH_SIZE = 100;
+
+type RegistryEnvelope = {
+  registry_outbox_id: string;
+  event_reference: string;
+  source_node_code: string;
+  change_code: string;
+  event_code: string;
+  object_type: string | null;
+  object_code: string | null;
+  registry_revision_ref: string | null;
+  payload: unknown;
+  evidence_reference: string | null;
+};
+
+function sendJson(response: ServerResponse, statusCode: number, body: unknown) {
+  response.statusCode = statusCode;
+  response.setHeader("content-type", "application/json; charset=utf-8");
+  response.end(JSON.stringify(body));
+}
+
+function getBatchSize(request: IncomingMessage) {
+  const url = new URL(request.url ?? "/api/registry-bridge", "https://registry-bridge.invalid");
+  const requested = Number(url.searchParams.get("limit") ?? DEFAULT_BATCH_SIZE);
+
+  if (!Number.isFinite(requested)) return DEFAULT_BATCH_SIZE;
+  return Math.max(1, Math.min(MAX_BATCH_SIZE, Math.trunc(requested)));
+}
+
+function isAuthorized(request: IncomingMessage) {
+  const secret = process.env.REGISTRY_BRIDGE_SECRET ?? process.env.CRON_SECRET;
+  if (!secret) return false;
+  return request.headers.authorization === `Bearer ${secret}`;
+}
+
+export default async function handler(request: IncomingMessage, response: ServerResponse) {
+  if (request.method !== "GET" && request.method !== "POST") {
+    response.setHeader("allow", "GET, POST");
+    return sendJson(response, 405, { ok: false, error: "method_not_allowed" });
+  }
+
+  if (!isAuthorized(request)) {
+    return sendJson(response, 401, { ok: false, error: "unauthorized" });
+  }
+
+  const sourceUrl = process.env.CWR_REGISTRY_DATABASE_URL;
+  const targetUrl = process.env.VSR_PUBLIC_DATABASE_URL;
+
+  if (!sourceUrl || !targetUrl) {
+    return sendJson(response, 503, {
+      ok: false,
+      error: "bridge_not_configured",
+      missing: [
+        ...(sourceUrl ? [] : ["CWR_REGISTRY_DATABASE_URL"]),
+        ...(targetUrl ? [] : ["VSR_PUBLIC_DATABASE_URL"]),
+      ],
+    });
+  }
+
+  const source = neon(sourceUrl);
+  const target = neon(targetUrl);
+  const batchSize = getBatchSize(request);
+
+  const envelopes = (await source`
+    select
+      registry_outbox_id,
+      event_reference,
+      source_node_code,
+      change_code,
+      event_code,
+      object_type,
+      object_code,
+      registry_revision_ref,
+      payload,
+      evidence_reference
+    from uoe_master.registry_outbox
+    where delivery_state in ('pending', 'failed')
+      and available_at <= now()
+    order by occurred_at asc, registry_outbox_id asc
+    limit ${batchSize}
+  `) as RegistryEnvelope[];
+
+  let delivered = 0;
+  let failed = 0;
+  const failures: Array<{ event_reference: string; error: string }> = [];
+
+  for (const envelope of envelopes) {
+    try {
+      await target`
+        insert into uoe_growth_runtime.registry_inbox (
+          source_node_code,
+          event_reference,
+          change_code,
+          event_code,
+          object_type,
+          object_code,
+          registry_revision_ref,
+          payload,
+          evidence_reference,
+          processing_state
+        ) values (
+          ${envelope.source_node_code},
+          ${envelope.event_reference},
+          ${envelope.change_code},
+          ${envelope.event_code},
+          ${envelope.object_type},
+          ${envelope.object_code},
+          ${envelope.registry_revision_ref},
+          ${JSON.stringify(envelope.payload)}::jsonb,
+          ${envelope.evidence_reference},
+          'received'
+        )
+        on conflict (source_node_code, event_reference) do nothing
+      `;
+
+      await target`
+        insert into uoe_growth_runtime.registry_sync_checkpoints (
+          registry_source_code,
+          last_outbox_event_ref,
+          last_registry_revision_ref,
+          last_processed_at,
+          checkpoint_context,
+          updated_at
+        ) values (
+          ${SOURCE_NODE_CODE},
+          ${envelope.event_reference},
+          ${envelope.registry_revision_ref},
+          now(),
+          jsonb_build_object('bridge', 'GEN-PART-PG-BRIDGE-003'),
+          now()
+        )
+        on conflict (registry_source_code) do update set
+          last_outbox_event_ref = excluded.last_outbox_event_ref,
+          last_registry_revision_ref = excluded.last_registry_revision_ref,
+          last_processed_at = excluded.last_processed_at,
+          checkpoint_context = coalesce(uoe_growth_runtime.registry_sync_checkpoints.checkpoint_context, '{}'::jsonb)
+            || excluded.checkpoint_context,
+          updated_at = excluded.updated_at
+      `;
+
+      await source`
+        update uoe_master.registry_outbox
+        set delivery_state = 'delivered',
+            delivered_at = now(),
+            attempt_count = attempt_count + 1,
+            last_error = null
+        where registry_outbox_id = ${envelope.registry_outbox_id}
+      `;
+
+      delivered += 1;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "unknown_bridge_error";
+      failed += 1;
+      failures.push({ event_reference: envelope.event_reference, error: message });
+
+      try {
+        await source`
+          update uoe_master.registry_outbox
+          set delivery_state = 'failed',
+              attempt_count = attempt_count + 1,
+              last_error = ${message}
+          where registry_outbox_id = ${envelope.registry_outbox_id}
+        `;
+      } catch {
+        // Preserve the original bridge error; a later run can retry the same envelope idempotently.
+      }
+    }
+  }
+
+  return sendJson(response, failed > 0 ? 207 : 200, {
+    ok: failed === 0,
+    bridge: "GEN-PART-PG-BRIDGE-003",
+    source: SOURCE_NODE_CODE,
+    scanned: envelopes.length,
+    delivered,
+    failed,
+    failures,
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/api/registry-bridge.ts
+++ b/api/registry-bridge.ts
@@ -2,8 +2,10 @@ import { neon } from "@neondatabase/serverless";
 import type { IncomingMessage, ServerResponse } from "node:http";
 
 const SOURCE_NODE_CODE = "CWR-REGISTRY";
+const BRIDGE_CODE = "GEN-PART-PG-BRIDGE-003";
 const DEFAULT_BATCH_SIZE = 25;
 const MAX_BATCH_SIZE = 100;
+const LEASE_MINUTES = 5;
 
 type RegistryEnvelope = {
   registry_outbox_id: string;
@@ -16,6 +18,7 @@ type RegistryEnvelope = {
   registry_revision_ref: string | null;
   payload: unknown;
   evidence_reference: string | null;
+  occurred_at: string | Date;
 };
 
 function sendJson(response: ServerResponse, statusCode: number, body: unknown) {
@@ -24,7 +27,7 @@ function sendJson(response: ServerResponse, statusCode: number, body: unknown) {
   response.end(JSON.stringify(body));
 }
 
-function getBatchSize(request: IncomingMessage) {
+export function getBatchSize(request: IncomingMessage) {
   const url = new URL(request.url ?? "/api/registry-bridge", "https://registry-bridge.invalid");
   const requested = Number(url.searchParams.get("limit") ?? DEFAULT_BATCH_SIZE);
 
@@ -32,7 +35,7 @@ function getBatchSize(request: IncomingMessage) {
   return Math.max(1, Math.min(MAX_BATCH_SIZE, Math.trunc(requested)));
 }
 
-function isAuthorized(request: IncomingMessage) {
+export function isAuthorized(request: IncomingMessage) {
   const secret = process.env.REGISTRY_BRIDGE_SECRET ?? process.env.CRON_SECRET;
   if (!secret) return false;
   return request.headers.authorization === `Bearer ${secret}`;
@@ -66,23 +69,37 @@ export default async function handler(request: IncomingMessage, response: Server
   const target = neon(targetUrl);
   const batchSize = getBatchSize(request);
 
+  // Claim a bounded batch in one atomic statement. `available_at` doubles as the
+  // lease expiry so an interrupted worker can be safely reclaimed later.
   const envelopes = (await source`
-    select
-      registry_outbox_id,
-      event_reference,
-      source_node_code,
-      change_code,
-      event_code,
-      object_type,
-      object_code,
-      registry_revision_ref,
-      payload,
-      evidence_reference
-    from uoe_master.registry_outbox
-    where delivery_state in ('pending', 'failed')
-      and available_at <= now()
-    order by occurred_at asc, registry_outbox_id asc
-    limit ${batchSize}
+    with candidates as (
+      select registry_outbox_id
+      from uoe_master.registry_outbox
+      where delivery_state in ('pending', 'failed', 'leased')
+        and available_at <= now()
+      order by occurred_at asc, registry_outbox_id asc
+      for update skip locked
+      limit ${batchSize}
+    )
+    update uoe_master.registry_outbox as outbox
+    set delivery_state = 'leased',
+        available_at = now() + (${LEASE_MINUTES} * interval '1 minute'),
+        attempt_count = attempt_count + 1,
+        last_error = null
+    from candidates
+    where outbox.registry_outbox_id = candidates.registry_outbox_id
+    returning
+      outbox.registry_outbox_id,
+      outbox.event_reference,
+      outbox.source_node_code,
+      outbox.change_code,
+      outbox.event_code,
+      outbox.object_type,
+      outbox.object_code,
+      outbox.registry_revision_ref,
+      outbox.payload,
+      outbox.evidence_reference,
+      outbox.occurred_at
   `) as RegistryEnvelope[];
 
   let delivered = 0;
@@ -118,6 +135,8 @@ export default async function handler(request: IncomingMessage, response: Server
         on conflict (source_node_code, event_reference) do nothing
       `;
 
+      // The checkpoint is observability state, not the transport authority. Guard
+      // it against regressing when two workers complete distinct leases out of order.
       await target`
         insert into uoe_growth_runtime.registry_sync_checkpoints (
           registry_source_code,
@@ -131,7 +150,10 @@ export default async function handler(request: IncomingMessage, response: Server
           ${envelope.event_reference},
           ${envelope.registry_revision_ref},
           now(),
-          jsonb_build_object('bridge', 'GEN-PART-PG-BRIDGE-003'),
+          jsonb_build_object(
+            'bridge', ${BRIDGE_CODE},
+            'last_event_occurred_at', ${envelope.occurred_at}::timestamptz
+          ),
           now()
         )
         on conflict (registry_source_code) do update set
@@ -141,15 +163,19 @@ export default async function handler(request: IncomingMessage, response: Server
           checkpoint_context = coalesce(uoe_growth_runtime.registry_sync_checkpoints.checkpoint_context, '{}'::jsonb)
             || excluded.checkpoint_context,
           updated_at = excluded.updated_at
+        where coalesce(
+          (uoe_growth_runtime.registry_sync_checkpoints.checkpoint_context->>'last_event_occurred_at')::timestamptz,
+          '-infinity'::timestamptz
+        ) <= ${envelope.occurred_at}::timestamptz
       `;
 
       await source`
         update uoe_master.registry_outbox
         set delivery_state = 'delivered',
             delivered_at = now(),
-            attempt_count = attempt_count + 1,
             last_error = null
         where registry_outbox_id = ${envelope.registry_outbox_id}
+          and delivery_state = 'leased'
       `;
 
       delivered += 1;
@@ -162,19 +188,20 @@ export default async function handler(request: IncomingMessage, response: Server
         await source`
           update uoe_master.registry_outbox
           set delivery_state = 'failed',
-              attempt_count = attempt_count + 1,
+              available_at = now() + interval '1 minute',
               last_error = ${message}
           where registry_outbox_id = ${envelope.registry_outbox_id}
+            and delivery_state = 'leased'
         `;
       } catch {
-        // Preserve the original bridge error; a later run can retry the same envelope idempotently.
+        // Preserve the original bridge error; the lease expires and becomes reclaimable.
       }
     }
   }
 
   return sendJson(response, failed > 0 ? 207 : 200, {
     ok: failed === 0,
-    bridge: "GEN-PART-PG-BRIDGE-003",
+    bridge: BRIDGE_CODE,
     source: SOURCE_NODE_CODE,
     scanned: envelopes.length,
     delivered,

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "description": "Synnergyze Genesis MCP service for governed VSR/Genesis integrations.",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.0",
+    "@neondatabase/serverless": "^1.0.1",
     "ajv": "^8.17.1",
     "algoliasearch": "^5.23.4",
     "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "type-check": "tsc --noEmit",
     "lint": "eslint --ext .ts src api",
     "test": "vitest",
+    "test:bridge": "vitest run api/registry-bridge.test.ts",
     "build": "npm run type-check",
     "debug": "mcp-inspector npm start"
   },

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,9 @@
     },
     "api/mcp.ts": {
       "maxDuration": 60
+    },
+    "api/registry-bridge.ts": {
+      "maxDuration": 60
     }
   },
   "rewrites": [
@@ -20,6 +23,10 @@
     {
       "source": "/mcp",
       "destination": "/api/mcp"
+    },
+    {
+      "source": "/registry-bridge",
+      "destination": "/api/registry-bridge"
     }
   ]
 }


### PR DESCRIPTION
Implements the application-layer bridge between `CWR-REGISTRY` and `VSR-PUBLIC`.

Scope:
- add `/api/registry-bridge` worker
- atomically lease pending/failed/expired CWR registry outbox envelopes
- idempotently insert into VSR registry inbox
- advance `registry_sync_checkpoints` without checkpoint regression
- mark source delivered only after target inbox/checkpoint succeed
- record source failure state for retry and lease recovery
- secure invocation with `REGISTRY_BRIDGE_SECRET` or Vercel `CRON_SECRET`
- declare database URLs as deployment secrets only
- add Neon serverless driver dependency
- add focused bridge tests and bridge-specific CI

Verification on head `7a7f8e436faf37214becb73cc1405fb87721d897`:
- `bridge-test`: PASS
- `lint`: PASS
- `type-check`: PASS
- live database round-trip: PASS (`claim -> inbox -> idempotent duplicate suppression -> checkpoint -> delivered`), verification rows removed and checkpoint restored
- repository-wide `test`: FAIL due to the pre-existing `src/commands/start-server.test.ts` transport-reuse defect (`Already connected to a transport`), reproduced on PR #19 before this bridge existed

Deployment lineage now reconciled by merged PR #22 / `GEN-DEPLOY-004`:
- `genesis` = governed integration branch and canonical Vercel runtime deployment source
- `main` = repository release/governance branch
- promotion to `main` does not transfer Vercel deployment authority away from `genesis`

Remaining external Vercel configuration gate:
- Production Branch must resolve to `genesis`
- Output Directory must be Auto-detect/cleared; stale `public` override must be removed
- required database URLs and bridge secret must be configured as encrypted Vercel environment variables
- do not manufacture a `public` folder as a workaround

Not included:
- no cron cadence yet
- no database credentials committed
- no FDW/dblink/direct cross-database credential storage

Related registry contract: `GEN-PART-PG-LINK-001` / `GEN-PART-PG-BRIDGE-003`.