### PR TITLE
Sync Alpha Node operating boundary into genesis

### DIFF
--- a/docs/alpha-node/ALPHA-NODE-001-OPERATING-BOUNDARY.md
+++ b/docs/alpha-node/ALPHA-NODE-001-OPERATING-BOUNDARY.md
@@ -1,0 +1,63 @@
+# ALPHA-NODE-001 — Governed Operating Boundary
+
+Status: ACTIVE REFERENCE
+
+## Canonical boundary
+
+ALPHA-NODE-001 is the precursor/reference/incubation node for the future BNR family. It is Registry-bearing.
+
+- Supabase: canonical Registry, licences, authority, consent, Warden policy and governed request state.
+- Neon: runtime/public participation, action requests, projections and operational workload.
+- RiverOS: governed event/evidence movement between sources and destinations.
+- Warden: authority/policy boundary. Authentication alone is not authorization.
+- Box: evidence/document/artifact store. Box object IDs are evidence references; Box is not authority.
+- GitHub: code, schemas, adapters, contracts and deployment manifests. No production secrets or private registry data.
+- Notion: human-readable operating knowledge, decisions, runbooks and reference views. Not canonical authority.
+- Airtable: optional lightweight operating queues/interfaces. It must not become Registry truth.
+
+## Execution invariant
+
+REQUEST != AUTHORITY != EXECUTION != EFFECT
+
+A consequential runtime path follows:
+
+REQUEST -> REGISTRY RESOLUTION -> WARDEN DECISION -> SHORT-LIVED AUTHORITY -> EXECUTION LEASE -> RUNTIME HANDOFF -> ACKNOWLEDGEMENT -> EFFECT EVIDENCE -> RECEIPT/STATE UPDATE
+
+## Cross-surface rule
+
+Every external work surface should carry stable references back to the Registry Desk, for example:
+
+- request_ref
+- authority_ref (reference only; never expose secret/token body)
+- handoff_id
+- execution_lease_id
+- Box evidence object ID
+- Git commit/PR reference
+- Notion page reference
+- Airtable record reference
+- RiverOS event/receipt reference
+
+No external surface may grant or infer authority merely because a record exists there.
+
+## Box root
+
+Existing Box folder: ALPHA-NODE-001
+Box folder ID: 408537078742
+
+Governed subfolders created:
+- 00-REGISTRY-DESK — 408585289562
+- 01-WARDEN-AUTHORITY — 408582575100
+- 02-RIVEROS-RECEIPTS — 408583230225
+- 03-RUNTIME-RELEASES — 408585579615
+- 04-OPERATING-DOCS — 408586463256
+
+## Public-repository safety
+
+This repository is public. Do not commit:
+- credentials, API keys, service-role keys, connection strings or secrets;
+- Warden token values/nonces/signatures;
+- private participant information;
+- private Box file bodies;
+- private registry rows or regulated evidence.
+
+Use references/IDs and redacted test fixtures only.

--- a/docs/alpha-node/CROSS-SURFACE-MANIFEST-CONTRACT.md
+++ b/docs/alpha-node/CROSS-SURFACE-MANIFEST-CONTRACT.md
@@ -1,0 +1,39 @@
+# ALPHA-NODE-001 Cross-Surface Manifest Contract
+
+Status: public-safe operating contract
+
+This document defines how ALPHA-NODE-001 projects one governed Registry request across supporting work surfaces without creating competing sources of truth.
+
+## Canonical boundaries
+
+- Supabase Registry / Warden: canonical identity, relationship, authority, licence, consent, request state and governance configuration.
+- Neon / RiverOS runtime: runtime actions, acknowledgements, event/evidence flow and rebuildable projections.
+- Box: restricted evidence and file artifacts.
+- GitHub: public-safe code, schemas, adapters, contracts and non-secret manifests only.
+- Notion: internal human-readable operating knowledge, runbooks and decision context.
+- Airtable: optional human operational queue/interface; never canonical authority or workflow state.
+
+## Manifest lifecycle
+
+A cross-surface manifest is generated from the canonical Registry request and may be versioned as the request progresses.
+
+`REQUEST -> WARDEN -> EXECUTION LEASE -> RUNTIME HANDOFF -> ACKNOWLEDGEMENT -> RECEIPT -> EFFECT (if any) -> REGISTRY UPDATE`
+
+Important separations:
+
+- REQUEST != AUTHORITY != EXECUTION
+- DELIVERY != ACKNOWLEDGEMENT != EFFECT
+- ACKNOWLEDGED does not imply EFFECT_OBSERVED
+- GitHub content must never contain Warden tokens, service secrets, private Registry rows, participant private data, or restricted Box evidence bodies.
+
+## Cross-surface reference rules
+
+Each surface stores or exposes only a reference appropriate to its classification. The Registry manifest stores surface references and their state (`ACTIVE`, `BLOCKED`, `SUPERSEDED`, `FAILED`). Supporting surfaces cannot independently grant authority or overwrite canonical Registry state.
+
+## Anti-replay requirement
+
+Every executable handoff is bound to one execution lease and, when authority is required, one single-use Warden decision token/change envelope. Runtime acknowledgement consumes that authority exactly once. Retries before acknowledgement must reconcile by idempotency key; replay after consumption must fail closed.
+
+## Alpha Node standing rule
+
+ALPHA-NODE-001 is the reference/incubation node. This contract is additive to the existing node architecture and does not supersede Registry/Warden/RiverOS boundaries.


### PR DESCRIPTION
Synchronizes the two additive Alpha Node documentation commits currently present on `main` but missing from `genesis`.

Scope is documentation-only:
- `docs/alpha-node/ALPHA-NODE-001-OPERATING-BOUNDARY.md`
- `docs/alpha-node/CROSS-SURFACE-MANIFEST-CONTRACT.md`

Purpose: remove the 2-commit `main` → `genesis` divergence before further governed Genesis integration work. No runtime, dependency, deployment, or database changes.