### PR TITLE
Sync corrected Genesis base into bridge branch

### DIFF
--- a/.genesis/branch.yaml
+++ b/.genesis/branch.yaml
@@ -6,8 +6,19 @@ genesis_branch:
   source_authority: Believers-common-group/genesis-stack
   first_point_of_contact: true
   production_branch: false
+  production_branch_scope: repository_release
+  runtime_deployment:
+    platform: vercel
+    project: synnergyze-genesis-mcp
+    source_branch: genesis
+    target_environment: production
+    output_directory_policy: auto_detect
+    effective_from: 2026-08-10T08:17:02Z
+    authority_commit: 413ba073cf3187a548896dd416cfb9bcce3f20c5
   workstream_pattern: genesis/<workstream>
   promotion:
     requires_validation: true
     target: main
+    effect: repository_release_only
   release_rule: Synnergyze node changes integrate here before promotion.
+  deployment_rule: Runtime deployment is sourced from genesis; promotion to main does not change the Vercel deployment source unless explicitly superseded.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -3,11 +3,39 @@
 ## Canonical deployment source
 
 - Repository: `Believers-common-group/mcp-node-synnergyze`
-- Branch: `genesis`
+- Runtime deployment branch: `genesis`
+- Repository release branch: `main`
 - Runtime: Node.js 22+
 - Remote MCP transport: Streamable HTTP
 - Health route: `/health`
 - MCP route: `/mcp`
+
+## Branch roles and lineage
+
+`genesis` is the governed integration branch and the canonical Vercel runtime deployment source for the Synnergyze Genesis MCP surface.
+
+`main` remains the repository release/governance branch. Promotion from `genesis` to `main` records a validated repository release; it does not by itself transfer Vercel production deployment authority away from `genesis`.
+
+This runtime rule is effective from commit `413ba073cf3187a548896dd416cfb9bcce3f20c5` (`fix(vercel): deploy only canonical genesis branch`, 10 August 2026) and is additive to the earlier Genesis branch contract.
+
+## Vercel project contract
+
+The Vercel project `synnergyze-genesis-mcp` must use:
+
+- Production Branch: `genesis`
+- Framework Preset: Other / auto-detected serverless functions
+- Output Directory: Auto-detect / cleared
+- Repository root as the project root unless explicitly superseded
+
+Do not set Output Directory to `public`, and do not create a placeholder `public` directory to satisfy a stale project setting. The repository already declares `outputDirectory: null` in `vercel.json`; the Vercel project-level override must also be cleared.
+
+Equivalent Vercel CLI remediation when operating with an authorized Vercel token:
+
+```bash
+vercel project update synnergyze-genesis-mcp --auto-detect output-directory
+```
+
+After the project setting is corrected, a push to `genesis` is the canonical Git-triggered deployment path. `vercel.json#ignoreCommand` intentionally suppresses non-`genesis` Git deployments.
 
 ## One-click Vercel import
 

--- a/docs/alpha-node/ALPHA-NODE-001-OPERATING-BOUNDARY.md
+++ b/docs/alpha-node/ALPHA-NODE-001-OPERATING-BOUNDARY.md
@@ -1,0 +1,63 @@
+# ALPHA-NODE-001 — Governed Operating Boundary
+
+Status: ACTIVE REFERENCE
+
+## Canonical boundary
+
+ALPHA-NODE-001 is the precursor/reference/incubation node for the future BNR family. It is Registry-bearing.
+
+- Supabase: canonical Registry, licences, authority, consent, Warden policy and governed request state.
+- Neon: runtime/public participation, action requests, projections and operational workload.
+- RiverOS: governed event/evidence movement between sources and destinations.
+- Warden: authority/policy boundary. Authentication alone is not authorization.
+- Box: evidence/document/artifact store. Box object IDs are evidence references; Box is not authority.
+- GitHub: code, schemas, adapters, contracts and deployment manifests. No production secrets or private registry data.
+- Notion: human-readable operating knowledge, decisions, runbooks and reference views. Not canonical authority.
+- Airtable: optional lightweight operating queues/interfaces. It must not become Registry truth.
+
+## Execution invariant
+
+REQUEST != AUTHORITY != EXECUTION != EFFECT
+
+A consequential runtime path follows:
+
+REQUEST -> REGISTRY RESOLUTION -> WARDEN DECISION -> SHORT-LIVED AUTHORITY -> EXECUTION LEASE -> RUNTIME HANDOFF -> ACKNOWLEDGEMENT -> EFFECT EVIDENCE -> RECEIPT/STATE UPDATE
+
+## Cross-surface rule
+
+Every external work surface should carry stable references back to the Registry Desk, for example:
+
+- request_ref
+- authority_ref (reference only; never expose secret/token body)
+- handoff_id
+- execution_lease_id
+- Box evidence object ID
+- Git commit/PR reference
+- Notion page reference
+- Airtable record reference
+- RiverOS event/receipt reference
+
+No external surface may grant or infer authority merely because a record exists there.
+
+## Box root
+
+Existing Box folder: ALPHA-NODE-001
+Box folder ID: 408537078742
+
+Governed subfolders created:
+- 00-REGISTRY-DESK — 408585289562
+- 01-WARDEN-AUTHORITY — 408582575100
+- 02-RIVEROS-RECEIPTS — 408583230225
+- 03-RUNTIME-RELEASES — 408585579615
+- 04-OPERATING-DOCS — 408586463256
+
+## Public-repository safety
+
+This repository is public. Do not commit:
+- credentials, API keys, service-role keys, connection strings or secrets;
+- Warden token values/nonces/signatures;
+- private participant information;
+- private Box file bodies;
+- private registry rows or regulated evidence.
+
+Use references/IDs and redacted test fixtures only.

--- a/docs/alpha-node/CROSS-SURFACE-MANIFEST-CONTRACT.md
+++ b/docs/alpha-node/CROSS-SURFACE-MANIFEST-CONTRACT.md
@@ -1,0 +1,39 @@
+# ALPHA-NODE-001 Cross-Surface Manifest Contract
+
+Status: public-safe operating contract
+
+This document defines how ALPHA-NODE-001 projects one governed Registry request across supporting work surfaces without creating competing sources of truth.
+
+## Canonical boundaries
+
+- Supabase Registry / Warden: canonical identity, relationship, authority, licence, consent, request state and governance configuration.
+- Neon / RiverOS runtime: runtime actions, acknowledgements, event/evidence flow and rebuildable projections.
+- Box: restricted evidence and file artifacts.
+- GitHub: public-safe code, schemas, adapters, contracts and non-secret manifests only.
+- Notion: internal human-readable operating knowledge, runbooks and decision context.
+- Airtable: optional human operational queue/interface; never canonical authority or workflow state.
+
+## Manifest lifecycle
+
+A cross-surface manifest is generated from the canonical Registry request and may be versioned as the request progresses.
+
+`REQUEST -> WARDEN -> EXECUTION LEASE -> RUNTIME HANDOFF -> ACKNOWLEDGEMENT -> RECEIPT -> EFFECT (if any) -> REGISTRY UPDATE`
+
+Important separations:
+
+- REQUEST != AUTHORITY != EXECUTION
+- DELIVERY != ACKNOWLEDGEMENT != EFFECT
+- ACKNOWLEDGED does not imply EFFECT_OBSERVED
+- GitHub content must never contain Warden tokens, service secrets, private Registry rows, participant private data, or restricted Box evidence bodies.
+
+## Cross-surface reference rules
+
+Each surface stores or exposes only a reference appropriate to its classification. The Registry manifest stores surface references and their state (`ACTIVE`, `BLOCKED`, `SUPERSEDED`, `FAILED`). Supporting surfaces cannot independently grant authority or overwrite canonical Registry state.
+
+## Anti-replay requirement
+
+Every executable handoff is bound to one execution lease and, when authority is required, one single-use Warden decision token/change envelope. Runtime acknowledgement consumes that authority exactly once. Retries before acknowledgement must reconcile by idempotency key; replay after consumption must fail closed.
+
+## Alpha Node standing rule
+
+ALPHA-NODE-001 is the reference/incubation node. This contract is additive to the existing node architecture and does not supersede Registry/Warden/RiverOS boundaries.


### PR DESCRIPTION
Brings the latest `genesis` base into `feature/gen-part-pg-bridge-003` before final bridge integration.

Includes only base-lineage changes already merged to `genesis`:
- Alpha Node operating-boundary / cross-surface manifest docs
- `GEN-DEPLOY-004` deployment-lineage clarification

Purpose: refresh the bridge branch against the current governed base and trigger CI on the actual merge candidate. No bridge logic is changed by this sync.