### PR TITLE
Superseded — GCS-20260812-001 governed provisioning command contracts

### DIFF
--- a/src/provisioning/contracts.test.ts
+++ b/src/provisioning/contracts.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  gateDeclareRequestSchema,
+  packageInstallRequestSchema,
+  programProvisionRequestSchema,
+  temporalConditionSchema,
+} from "./contracts.ts";
+
+const actor = {
+  digitalmeId: "DM-TEST-001",
+  actingCapacity: "NODE_OPERATOR",
+};
+
+const baseEnvelope = {
+  commandId: "11111111-1111-4111-8111-111111111111",
+  subjectRef: "SUBJECT-001",
+  actor,
+  correlationId: "22222222-2222-4222-8222-222222222222",
+  idempotencyKey: "idem-test-001",
+  evidenceRefs: [],
+};
+
+describe("Registry provisioning contracts", () => {
+  it("accepts a Program provisioning request", () => {
+    const parsed = programProvisionRequestSchema.parse({
+      envelope: { ...baseEnvelope, commandType: "PROGRAM_PROVISION" },
+      templateRef: "CLDR-RELEASE-001@1.0.0",
+      editionCode: "CLDR-50",
+      externalConstraintRefs: [],
+      overrides: {},
+    });
+
+    expect(parsed.envelope.commandType).toBe("PROGRAM_PROVISION");
+    expect(parsed.editionCode).toBe("CLDR-50");
+  });
+
+  it("requires evidence when declaring a Gate", () => {
+    expect(() =>
+      gateDeclareRequestSchema.parse({
+        envelope: { ...baseEnvelope, commandType: "GATE_DECLARE" },
+        gateEventRef: "CLDR-49-DATA-SLUSH",
+      }),
+    ).toThrow();
+  });
+
+  it("keeps package installation as a request rather than an implicit enable", () => {
+    const parsed = packageInstallRequestSchema.parse({
+      envelope: { ...baseEnvelope, commandType: "PACKAGE_INSTALL_REQUEST" },
+      packageRef: "QR-DESIGN-001@2.1.0",
+      nodeRef: "BNR-IN-KA-BLR-0001",
+    });
+
+    expect(parsed.envelope.commandType).toBe("PACKAGE_INSTALL_REQUEST");
+  });
+
+  it("accepts Sentinel temporal facts without a Registry state mutation", () => {
+    const parsed = temporalConditionSchema.parse({
+      conditionId: "33333333-3333-4333-8333-333333333333",
+      conditionType: "DEADLINE_DUE",
+      subjectRef: "CLDR-49-ALPHA-1",
+      observedAt: "2026-08-19T00:00:00Z",
+      source: "SENTINEL_CLOCK",
+    });
+
+    expect(parsed.source).toBe("SENTINEL_CLOCK");
+  });
+});

--- a/src/provisioning/contracts.ts
+++ b/src/provisioning/contracts.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+
+export const registryActorSchema = z.object({
+  digitalmeId: z.string().min(1),
+  actingCapacity: z.string().min(1),
+  representedEntity: z.string().min(1).optional(),
+});
+
+export const registryCommandEnvelopeSchema = z.object({
+  commandId: z.string().uuid(),
+  commandType: z.enum([
+    "PROGRAM_PROVISION",
+    "SCHEDULE_PROPOSE",
+    "SCHEDULE_BASELINE_APPROVE",
+    "SCHEDULE_AMEND",
+    "GATE_CHECK",
+    "GATE_DECLARE",
+    "GATE_HOLD",
+    "EXCEPTION_REQUEST",
+    "EXCEPTION_APPROVE",
+    "EXCEPTION_DENY",
+    "PACKAGE_INSTALL_REQUEST",
+    "PACKAGE_ENABLE_REQUEST",
+    "PACKAGE_SUSPEND_REQUEST",
+    "PACKAGE_REVOKE_REQUEST",
+  ]),
+  subjectRef: z.string().min(1),
+  actor: registryActorSchema,
+  expectedRegistryVersion: z.number().int().positive().optional(),
+  requestedEffectiveAt: z.string().datetime().optional(),
+  evidenceRefs: z.array(z.string().min(1)).default([]),
+  reason: z.string().min(1).optional(),
+  correlationId: z.string().uuid(),
+  idempotencyKey: z.string().min(8),
+});
+
+export const programProvisionRequestSchema = z.object({
+  envelope: registryCommandEnvelopeSchema.extend({
+    commandType: z.literal("PROGRAM_PROVISION"),
+  }),
+  templateRef: z.string().min(1),
+  editionCode: z.string().min(2),
+  authorityDomainRef: z.string().min(1).optional(),
+  hostPlaceRef: z.string().min(1).optional(),
+  externalConstraintRefs: z.array(z.string().min(1)).default([]),
+  overrides: z.record(z.unknown()).default({}),
+});
+
+export const gateDeclareRequestSchema = z.object({
+  envelope: registryCommandEnvelopeSchema.extend({
+    commandType: z.literal("GATE_DECLARE"),
+  }),
+  gateEventRef: z.string().min(1),
+  evidenceSetRef: z.string().min(1),
+});
+
+export const packageInstallRequestSchema = z.object({
+  envelope: registryCommandEnvelopeSchema.extend({
+    commandType: z.literal("PACKAGE_INSTALL_REQUEST"),
+  }),
+  packageRef: z.string().min(1),
+  nodeRef: z.string().min(1),
+  configurationRef: z.string().min(1).optional(),
+});
+
+export const registryDecisionSchema = z.object({
+  decisionId: z.string().uuid(),
+  disposition: z.enum([
+    "ALLOW",
+    "DENY",
+    "CONDITIONAL",
+    "REQUIRE_APPROVAL",
+    "REQUIRE_EVIDENCE",
+    "ESCALATE",
+  ]),
+  policyVersion: z.string().min(1),
+  conditions: z.array(z.string()).default([]),
+  reasonCodes: z.array(z.string()).default([]),
+  validUntil: z.string().datetime().optional(),
+});
+
+export const temporalConditionSchema = z.object({
+  conditionId: z.string().uuid(),
+  conditionType: z.enum([
+    "TIME_REACHED",
+    "WINDOW_OPEN",
+    "WINDOW_CLOSED",
+    "DEADLINE_DUE",
+    "DEADLINE_MISSED",
+    "RECURRENCE_DUE",
+    "DEPENDENCY_TIME_SATISFIED",
+  ]),
+  subjectRef: z.string().min(1),
+  observedAt: z.string().datetime(),
+  source: z.literal("SENTINEL_CLOCK"),
+});
+
+export type RegistryCommandEnvelope = z.infer<typeof registryCommandEnvelopeSchema>;
+export type ProgramProvisionRequest = z.infer<typeof programProvisionRequestSchema>;
+export type GateDeclareRequest = z.infer<typeof gateDeclareRequestSchema>;
+export type PackageInstallRequest = z.infer<typeof packageInstallRequestSchema>;
+export type RegistryDecision = z.infer<typeof registryDecisionSchema>;
+export type TemporalCondition = z.infer<typeof temporalConditionSchema>;

--- a/src/provisioning/flow.test.ts
+++ b/src/provisioning/flow.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { GateDeclareRequest, RegistryDecision, TemporalCondition } from "./contracts.ts";
+import { evaluateGovernedGateCommand } from "./flow.ts";
+
+const request: GateDeclareRequest = {
+  envelope: {
+    commandId: "11111111-1111-4111-8111-111111111111",
+    commandType: "GATE_DECLARE",
+    subjectRef: "CLDR-V49-2026",
+    actor: {
+      digitalmeId: "DM-TEST-001",
+      actingCapacity: "RELEASE_MANAGER",
+    },
+    evidenceRefs: ["EVIDENCE-SET-CLDR-V49-DATA-SLUSH"],
+    correlationId: "22222222-2222-4222-8222-222222222222",
+    idempotencyKey: "cldr-v49-data-slush-declare",
+  },
+  gateEventRef: "CLDR-V49-2026-DATA_SLUSH",
+  evidenceSetRef: "EVIDENCE-SET-CLDR-V49-DATA-SLUSH",
+};
+
+const temporal: TemporalCondition = {
+  conditionId: "33333333-3333-4333-8333-333333333333",
+  conditionType: "DEADLINE_DUE",
+  subjectRef: "CLDR-V49-2026-DATA_SLUSH",
+  observedAt: "2026-08-12T18:51:00Z",
+  source: "SENTINEL_CLOCK",
+};
+
+const allowDecision: RegistryDecision = {
+  decisionId: "44444444-4444-4444-8444-444444444444",
+  disposition: "ALLOW",
+  policyVersion: "CLDR-GP-DATA-SLUSH@1",
+  conditions: [],
+  reasonCodes: ["AUTHORITY_AND_REQUIREMENTS_VERIFIED"],
+};
+
+describe("governed provisioning flow", () => {
+  it("does not turn a passed Sentinel clock fact into Registry authority", () => {
+    const result = evaluateGovernedGateCommand({
+      request,
+      temporalCondition: temporal,
+      evidenceSatisfied: true,
+      currentState: "DUE",
+    });
+
+    expect(result).toEqual({
+      disposition: "REQUIRE_AUTHORITY",
+      reason: "SENTINEL_FACT_PRESENT_BUT_WARDEN_DECISION_REQUIRED",
+    });
+  });
+
+  it("does not commit an allowed decision without mandatory evidence", () => {
+    const result = evaluateGovernedGateCommand({
+      request,
+      decision: allowDecision,
+      temporalCondition: temporal,
+      evidenceSatisfied: false,
+      currentState: "DUE",
+    });
+
+    expect(result.disposition).toBe("REQUIRE_EVIDENCE");
+    expect(result.transition).toBeUndefined();
+    expect(result.outbox).toBeUndefined();
+  });
+
+  it("returns transition and River outbox proposals only after authority and evidence", () => {
+    const result = evaluateGovernedGateCommand({
+      request,
+      decision: allowDecision,
+      temporalCondition: temporal,
+      evidenceSatisfied: true,
+      currentState: "DUE",
+    });
+
+    expect(result.disposition).toBe("READY_TO_COMMIT");
+    expect(result.transition).toMatchObject({
+      subjectRef: "CLDR-V49-2026-DATA_SLUSH",
+      fromState: "DUE",
+      toState: "EFFECTIVE",
+      authorityDecisionRef: allowDecision.decisionId,
+      evidenceSetRef: request.evidenceSetRef,
+    });
+    expect(result.outbox).toMatchObject({
+      eventType: "registry.gate.transition.proposed",
+      aggregateRef: "CLDR-V49-2026-DATA_SLUSH",
+      authorityDecisionRef: allowDecision.decisionId,
+      payload: {
+        commandType: "GATE_DECLARE",
+        proposedState: "EFFECTIVE",
+        temporalCondition: {
+          conditionType: "DEADLINE_DUE",
+          source: "SENTINEL_CLOCK",
+        },
+      },
+    });
+  });
+
+  it("preserves a Warden denial even when the planned time has passed", () => {
+    const result = evaluateGovernedGateCommand({
+      request,
+      temporalCondition: temporal,
+      evidenceSatisfied: true,
+      decision: { ...allowDecision, disposition: "DENY", reasonCodes: ["REQUIREMENTS_NOT_MET"] },
+      currentState: "DUE",
+    });
+
+    expect(result).toEqual({ disposition: "DENIED", reason: "WARDEN_DENIED" });
+  });
+});

--- a/src/provisioning/flow.ts
+++ b/src/provisioning/flow.ts
@@ -1,0 +1,152 @@
+import type {
+  GateDeclareRequest,
+  RegistryDecision,
+  TemporalCondition,
+} from "./contracts.ts";
+
+export type GateFlowDisposition =
+  | "REQUIRE_AUTHORITY"
+  | "REQUIRE_EVIDENCE"
+  | "DENIED"
+  | "CONDITIONAL"
+  | "READY_TO_COMMIT";
+
+export type RegistryTransitionProposal = {
+  subjectType: "GATE_EVENT";
+  subjectRef: string;
+  fromState: "DUE" | "READY" | "HELD" | "PLANNED";
+  toState: "EFFECTIVE";
+  transitionType: "AUTHORITY_DECLARED_GATE";
+  actorRef: string;
+  authorityDecisionRef: string;
+  evidenceSetRef: string;
+  correlationId: string;
+  causationId: string;
+};
+
+export type RiverOutboxProposal = {
+  eventType: "registry.gate.transition.proposed";
+  aggregateType: "GATE_EVENT";
+  aggregateRef: string;
+  correlationId: string;
+  causationId: string;
+  authorityDecisionRef: string;
+  evidenceSetRef: string;
+  payload: {
+    commandType: "GATE_DECLARE";
+    proposedState: "EFFECTIVE";
+    temporalCondition?: {
+      conditionType: TemporalCondition["conditionType"];
+      observedAt: string;
+      source: "SENTINEL_CLOCK";
+    };
+  };
+};
+
+export type GateFlowResult = {
+  disposition: GateFlowDisposition;
+  reason: string;
+  transition?: RegistryTransitionProposal;
+  outbox?: RiverOutboxProposal;
+};
+
+export type GateFlowInput = {
+  request: GateDeclareRequest;
+  decision?: RegistryDecision;
+  temporalCondition?: TemporalCondition;
+  evidenceSatisfied: boolean;
+  currentState?: "DUE" | "READY" | "HELD" | "PLANNED";
+};
+
+/**
+ * Evaluates whether Synnergyze may propose a governed Gate transition.
+ *
+ * This function deliberately does not mutate Registry state and does not publish
+ * to RiverOS. It returns commit/outbox proposals only after Warden authority and
+ * evidence are both present. Sentinel Clock facts are context, never authority.
+ */
+export function evaluateGovernedGateCommand(input: GateFlowInput): GateFlowResult {
+  const { request, decision, temporalCondition, evidenceSatisfied } = input;
+
+  if (temporalCondition && temporalCondition.subjectRef !== request.gateEventRef) {
+    return {
+      disposition: "REQUIRE_AUTHORITY",
+      reason: "TEMPORAL_FACT_SUBJECT_MISMATCH",
+    };
+  }
+
+  if (!decision) {
+    return {
+      disposition: "REQUIRE_AUTHORITY",
+      reason: temporalCondition
+        ? "SENTINEL_FACT_PRESENT_BUT_WARDEN_DECISION_REQUIRED"
+        : "WARDEN_DECISION_REQUIRED",
+    };
+  }
+
+  if (decision.disposition === "DENY") {
+    return { disposition: "DENIED", reason: "WARDEN_DENIED" };
+  }
+
+  if (decision.disposition === "CONDITIONAL") {
+    return { disposition: "CONDITIONAL", reason: "WARDEN_CONDITIONS_UNRESOLVED" };
+  }
+
+  if (decision.disposition !== "ALLOW") {
+    return {
+      disposition:
+        decision.disposition === "REQUIRE_EVIDENCE" ? "REQUIRE_EVIDENCE" : "REQUIRE_AUTHORITY",
+      reason: `WARDEN_${decision.disposition}`,
+    };
+  }
+
+  if (!evidenceSatisfied) {
+    return {
+      disposition: "REQUIRE_EVIDENCE",
+      reason: "MANDATORY_GATE_EVIDENCE_NOT_SATISFIED",
+    };
+  }
+
+  const transition: RegistryTransitionProposal = {
+    subjectType: "GATE_EVENT",
+    subjectRef: request.gateEventRef,
+    fromState: input.currentState ?? "DUE",
+    toState: "EFFECTIVE",
+    transitionType: "AUTHORITY_DECLARED_GATE",
+    actorRef: request.envelope.actor.digitalmeId,
+    authorityDecisionRef: decision.decisionId,
+    evidenceSetRef: request.evidenceSetRef,
+    correlationId: request.envelope.correlationId,
+    causationId: request.envelope.commandId,
+  };
+
+  const outbox: RiverOutboxProposal = {
+    eventType: "registry.gate.transition.proposed",
+    aggregateType: "GATE_EVENT",
+    aggregateRef: request.gateEventRef,
+    correlationId: request.envelope.correlationId,
+    causationId: request.envelope.commandId,
+    authorityDecisionRef: decision.decisionId,
+    evidenceSetRef: request.evidenceSetRef,
+    payload: {
+      commandType: "GATE_DECLARE",
+      proposedState: "EFFECTIVE",
+      ...(temporalCondition
+        ? {
+            temporalCondition: {
+              conditionType: temporalCondition.conditionType,
+              observedAt: temporalCondition.observedAt,
+              source: temporalCondition.source,
+            },
+          }
+        : {}),
+    },
+  };
+
+  return {
+    disposition: "READY_TO_COMMIT",
+    reason: "WARDEN_ALLOWED_AND_EVIDENCE_SATISFIED",
+    transition,
+    outbox,
+  };
+}


### PR DESCRIPTION
## Superseded by #66

This draft is closed because its implementation surface is stale against current `genesis`: `src/**` is excluded from the active TypeScript programme and the current Warden contract/checkpoint boundary has evolved beyond the decision shape used here.

The governed provisioning intent is carried forward by #66 on a fresh branch from current `genesis`, with exact-head lint, type-check and full test checks green. #66 returns proposals only, requires a current Warden `ALLOW`, preserves evidence as a separate requirement, and explicitly requires a fresh execution checkpoint before authoritative effect.

## Historical scope retained for lineage

Adds the first Synnergyze contracts and decision-flow boundary for governed Registry provisioning.

### Invariants
- Synnergyze requests Registry actions; it does not directly mutate authoritative Registry state.
- Package install remains a request, not implicit enablement.
- Gate declaration requires evidence.
- Sentinel emits temporal facts and cannot activate governed state.
- Warden authority and mandatory evidence must both be satisfied before a transition/outbox proposal is returned.

### Historical validation
- Type-check: PASS.
- Lint: PASS.
- `src/provisioning/contracts.test.ts`: 4/4 PASS.
- `src/provisioning/flow.test.ts`: 4/4 PASS.
- Full test run on this stale head: 36 PASS / 3 FAIL in the then-existing `src/commands/start-server.test.ts` transport-reuse surface.

### Boundary
No merge, production execution, database promotion, Registry mutation, River publication, or live activation is implied by this historical draft.