### PR TITLE
GEN-PART-PG-BRIDGE-003: harden source isolation and lease ownership

### DIFF
--- a/.github/workflows/bridge-test.yml
+++ b/.github/workflows/bridge-test.yml
@@ -6,7 +6,6 @@ on:
       - 'api/registry-bridge.ts'
       - 'api/registry-bridge.test.ts'
       - 'package.json'
-      - 'package-lock.json'
       - '.github/workflows/bridge-test.yml'
 
 jobs:
@@ -22,7 +21,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm i
 
       - name: Run bridge tests
         run: npm run test:bridge

--- a/.github/workflows/bridge-test.yml
+++ b/.github/workflows/bridge-test.yml
@@ -6,6 +6,7 @@ on:
       - 'api/registry-bridge.ts'
       - 'api/registry-bridge.test.ts'
       - 'package.json'
+      - 'package-lock.json'
       - '.github/workflows/bridge-test.yml'
 
 jobs:
@@ -21,7 +22,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install dependencies
-        run: npm i
+        run: npm ci
 
       - name: Run bridge tests
         run: npm run test:bridge

--- a/api/registry-bridge.test.ts
+++ b/api/registry-bridge.test.ts
@@ -2,6 +2,11 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const queries = vi.hoisted(() => ({ source: [] as string[], target: [] as string[] }));
+const behavior = vi.hoisted(() => ({
+  insertConflict: false,
+  existingInboxMatches: true,
+  finalizeSucceeds: true,
+}));
 
 vi.mock("@neondatabase/serverless", () => ({
   neon: (url: string) => async (strings: TemplateStringsArray, ..._values: unknown[]) => {
@@ -23,8 +28,23 @@ vi.mock("@neondatabase/serverless", () => ({
           payload: { ok: true },
           evidence_reference: null,
           occurred_at: "2026-08-12T17:00:00.000Z",
+          attempt_count: 3,
         },
       ];
+    }
+
+    if (url === "target-db" && sql.includes("insert into uoe_growth_runtime.registry_inbox")) {
+      return behavior.insertConflict ? [] : [{ event_reference: "EVT-001" }];
+    }
+
+    if (url === "target-db" && sql.includes("select 1 as matched")) {
+      return behavior.existingInboxMatches ? [{ matched: 1 }] : [];
+    }
+
+    if (url === "source-db" && sql.includes("delivery_state = 'delivered'")) {
+      return behavior.finalizeSucceeds
+        ? [{ registry_outbox_id: "00000000-0000-0000-0000-000000000001" }]
+        : [];
     }
 
     return [];
@@ -74,10 +94,19 @@ function response() {
 
 const originalEnv = { ...process.env };
 
+function configureBridge() {
+  process.env.REGISTRY_BRIDGE_SECRET = "bridge-secret";
+  process.env.CWR_REGISTRY_DATABASE_URL = "source-db";
+  process.env.VSR_PUBLIC_DATABASE_URL = "target-db";
+}
+
 describe("GEN-PART-PG-BRIDGE-003", () => {
   beforeEach(() => {
     queries.source.length = 0;
     queries.target.length = 0;
+    behavior.insertConflict = false;
+    behavior.existingInboxMatches = true;
+    behavior.finalizeSucceeds = true;
     process.env = { ...originalEnv };
     delete process.env.REGISTRY_BRIDGE_SECRET;
     delete process.env.CRON_SECRET;
@@ -95,10 +124,12 @@ describe("GEN-PART-PG-BRIDGE-003", () => {
     expect(getBatchSize(request({ url: "/api/registry-bridge?limit=not-a-number" }))).toBe(25);
   });
 
-  it("requires the configured bearer secret", () => {
+  it("accepts either configured bridge or cron bearer secret", () => {
     process.env.REGISTRY_BRIDGE_SECRET = "bridge-secret";
+    process.env.CRON_SECRET = "cron-secret";
 
     expect(isAuthorized(request({ headers: { authorization: "Bearer bridge-secret" } }))).toBe(true);
+    expect(isAuthorized(request({ headers: { authorization: "Bearer cron-secret" } }))).toBe(true);
     expect(isAuthorized(request({ headers: { authorization: "Bearer wrong" } }))).toBe(false);
   });
 
@@ -132,10 +163,8 @@ describe("GEN-PART-PG-BRIDGE-003", () => {
     expect(queries.target).toHaveLength(0);
   });
 
-  it("claims before delivery and marks source delivered only after target writes", async () => {
-    process.env.REGISTRY_BRIDGE_SECRET = "bridge-secret";
-    process.env.CWR_REGISTRY_DATABASE_URL = "source-db";
-    process.env.VSR_PUBLIC_DATABASE_URL = "target-db";
+  it("claims only CWR source rows and finalizes the exact lease generation", async () => {
+    configureBridge();
     const output = response();
 
     await handler(
@@ -153,10 +182,71 @@ describe("GEN-PART-PG-BRIDGE-003", () => {
       failed: 0,
     });
 
-    expect(queries.source[0]).toContain("delivery_state = 'leased'");
+    expect(queries.source[0]).toContain("where source_node_code = ?");
+    expect(queries.source[0]).toContain("outbox.attempt_count");
     expect(queries.target[0]).toContain("registry_inbox");
     expect(queries.target[0]).toContain("on conflict (source_node_code, event_reference) do nothing");
     expect(queries.target[1]).toContain("registry_sync_checkpoints");
     expect(queries.source[1]).toContain("delivery_state = 'delivered'");
+    expect(queries.source[1]).toContain("attempt_count = ?");
+  });
+
+  it("accepts an identical inbox retry after duplicate suppression", async () => {
+    configureBridge();
+    behavior.insertConflict = true;
+    behavior.existingInboxMatches = true;
+    const output = response();
+
+    await handler(
+      request({ headers: { authorization: "Bearer bridge-secret" } }),
+      output.res,
+    );
+
+    expect(output.statusCode).toBe(200);
+    expect(JSON.parse(output.body)).toMatchObject({ ok: true, delivered: 1, failed: 0 });
+    expect(queries.target.some((sql) => sql.includes("select 1 as matched"))).toBe(true);
+  });
+
+  it("rejects an idempotency-key collision with different inbox content", async () => {
+    configureBridge();
+    behavior.insertConflict = true;
+    behavior.existingInboxMatches = false;
+    const output = response();
+
+    await handler(
+      request({ headers: { authorization: "Bearer bridge-secret" } }),
+      output.res,
+    );
+
+    expect(output.statusCode).toBe(207);
+    expect(JSON.parse(output.body)).toMatchObject({
+      ok: false,
+      delivered: 0,
+      failed: 1,
+      failures: [{ event_reference: "EVT-001", error: "registry_inbox_idempotency_collision" }],
+    });
+    expect(queries.target.some((sql) => sql.includes("registry_sync_checkpoints"))).toBe(false);
+    expect(queries.source.some((sql) => sql.includes("delivery_state = 'failed'"))).toBe(true);
+  });
+
+  it("does not finalize a lease reclaimed by another worker", async () => {
+    configureBridge();
+    behavior.finalizeSucceeds = false;
+    const output = response();
+
+    await handler(
+      request({ headers: { authorization: "Bearer bridge-secret" } }),
+      output.res,
+    );
+
+    expect(output.statusCode).toBe(207);
+    expect(JSON.parse(output.body)).toMatchObject({
+      ok: false,
+      delivered: 0,
+      failed: 1,
+      failures: [{ event_reference: "EVT-001", error: "lease_lost_before_finalize" }],
+    });
+    expect(queries.source.some((sql) => sql.includes("delivery_state = 'failed'"))).toBe(true);
+    expect(queries.source.at(-1)).toContain("attempt_count = ?");
   });
 });

--- a/api/registry-bridge.ts
+++ b/api/registry-bridge.ts
@@ -19,7 +19,11 @@ type RegistryEnvelope = {
   payload: unknown;
   evidence_reference: string | null;
   occurred_at: string | Date;
+  attempt_count: number;
 };
+
+type OutboxIdRow = { registry_outbox_id: string };
+type InboxMatchRow = { matched: number };
 
 function sendJson(response: ServerResponse, statusCode: number, body: unknown) {
   response.statusCode = statusCode;
@@ -36,9 +40,15 @@ export function getBatchSize(request: IncomingMessage) {
 }
 
 export function isAuthorized(request: IncomingMessage) {
-  const secret = process.env.REGISTRY_BRIDGE_SECRET ?? process.env.CRON_SECRET;
-  if (!secret) return false;
-  return request.headers.authorization === `Bearer ${secret}`;
+  const authorization = request.headers.authorization;
+  if (typeof authorization !== "string" || !authorization.startsWith("Bearer ")) return false;
+
+  const presented = authorization.slice("Bearer ".length);
+  const secrets = [process.env.REGISTRY_BRIDGE_SECRET, process.env.CRON_SECRET].filter(
+    (secret): secret is string => Boolean(secret),
+  );
+
+  return secrets.some((secret) => presented === secret);
 }
 
 export default async function handler(request: IncomingMessage, response: ServerResponse) {
@@ -69,13 +79,14 @@ export default async function handler(request: IncomingMessage, response: Server
   const target = neon(targetUrl);
   const batchSize = getBatchSize(request);
 
-  // Claim a bounded batch in one atomic statement. `available_at` doubles as the
-  // lease expiry so an interrupted worker can be safely reclaimed later.
+  // Claim only this bridge's governed source. `attempt_count` is the lease generation:
+  // later finalize/failure writes must still own the exact generation they claimed.
   const envelopes = (await source`
     with candidates as (
       select registry_outbox_id
       from uoe_master.registry_outbox
-      where delivery_state in ('pending', 'failed', 'leased')
+      where source_node_code = ${SOURCE_NODE_CODE}
+        and delivery_state in ('pending', 'failed', 'leased')
         and available_at <= now()
       order by occurred_at asc, registry_outbox_id asc
       for update skip locked
@@ -99,7 +110,8 @@ export default async function handler(request: IncomingMessage, response: Server
       outbox.registry_revision_ref,
       outbox.payload,
       outbox.evidence_reference,
-      outbox.occurred_at
+      outbox.occurred_at,
+      outbox.attempt_count
   `) as RegistryEnvelope[];
 
   let delivered = 0;
@@ -108,7 +120,7 @@ export default async function handler(request: IncomingMessage, response: Server
 
   for (const envelope of envelopes) {
     try {
-      await target`
+      const inserted = (await target`
         insert into uoe_growth_runtime.registry_inbox (
           source_node_code,
           event_reference,
@@ -133,7 +145,29 @@ export default async function handler(request: IncomingMessage, response: Server
           'received'
         )
         on conflict (source_node_code, event_reference) do nothing
-      `;
+        returning event_reference
+      `) as Array<{ event_reference: string }>;
+
+      if (inserted.length === 0) {
+        const existingMatch = (await target`
+          select 1 as matched
+          from uoe_growth_runtime.registry_inbox
+          where source_node_code = ${envelope.source_node_code}
+            and event_reference = ${envelope.event_reference}
+            and change_code is not distinct from ${envelope.change_code}
+            and event_code is not distinct from ${envelope.event_code}
+            and object_type is not distinct from ${envelope.object_type}
+            and object_code is not distinct from ${envelope.object_code}
+            and registry_revision_ref is not distinct from ${envelope.registry_revision_ref}
+            and payload is not distinct from ${JSON.stringify(envelope.payload)}::jsonb
+            and evidence_reference is not distinct from ${envelope.evidence_reference}
+          limit 1
+        `) as InboxMatchRow[];
+
+        if (existingMatch.length !== 1) {
+          throw new Error("registry_inbox_idempotency_collision");
+        }
+      }
 
       // The checkpoint is observability state, not the transport authority. Guard
       // it against regressing when two workers complete distinct leases out of order.
@@ -169,14 +203,21 @@ export default async function handler(request: IncomingMessage, response: Server
         ) <= ${envelope.occurred_at}::timestamptz
       `;
 
-      await source`
+      const finalized = (await source`
         update uoe_master.registry_outbox
         set delivery_state = 'delivered',
             delivered_at = now(),
             last_error = null
         where registry_outbox_id = ${envelope.registry_outbox_id}
+          and source_node_code = ${SOURCE_NODE_CODE}
           and delivery_state = 'leased'
-      `;
+          and attempt_count = ${envelope.attempt_count}
+        returning registry_outbox_id
+      `) as OutboxIdRow[];
+
+      if (finalized.length !== 1) {
+        throw new Error("lease_lost_before_finalize");
+      }
 
       delivered += 1;
     } catch (error) {
@@ -191,7 +232,9 @@ export default async function handler(request: IncomingMessage, response: Server
               available_at = now() + interval '1 minute',
               last_error = ${message}
           where registry_outbox_id = ${envelope.registry_outbox_id}
+            and source_node_code = ${SOURCE_NODE_CODE}
             and delivery_state = 'leased'
+            and attempt_count = ${envelope.attempt_count}
         `;
       } catch {
         // Preserve the original bridge error; the lease expires and becomes reclaimable.


### PR DESCRIPTION
Follow-up hardening for merged PR #20.

Scope:
- constrain outbox claims to `CWR-REGISTRY`
- treat `attempt_count` as the lease generation and require it on finalize/failure writes
- reject stale workers that lose lease ownership before source finalization
- distinguish identical inbox retries from idempotency-key collisions
- accept either configured `REGISTRY_BRIDGE_SECRET` or `CRON_SECRET`
- add focused regression tests for source isolation, duplicate acceptance, collision rejection, and stale lease finalization

Verification on head `f07c673dcc9ef82c89e834f432d000236f0cc870`:
- `bridge-test`: PASS
- `type-check`: PASS
- `lint` step: PASS
- repository-wide `test`: currently inherits the pre-existing transport-reuse failure from `genesis`; PR #26 fixes that defect with repository-wide test/lint/type-check all PASS

Merge order:
1. merge #26 into `genesis`
2. update/rebase this branch onto the new `genesis`
3. require a fresh all-green run before merging #25

Intentionally not included:
- no schema migration
- no cron cadence
- no database credentials
- no Vercel project-setting workaround or manufactured `public` directory
- no lockfile introduction; this repository currently has no `package-lock.json`, so the existing `npm i` CI install remains unchanged

External deployment gate remains: the canonical `synnergyze-genesis-mcp` Vercel project is still treating `main` as production and still carries the stale output-directory behavior. Production Branch must be `genesis`; Output Directory must be Auto-detect/cleared; encrypted database URLs and bridge secret must be configured; scheduled production flow stays disabled until deployment and live bridge verification succeed.