### PR TITLE
Fix start-server transport-reuse tests

### DIFF
--- a/src/commands/start-server.test.ts
+++ b/src/commands/start-server.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 
-import { startServer } from "./start-server.ts";
+import { createServer, startServer } from "./start-server.ts";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { setupServer } from "msw/node";
 import { http } from "msw";
@@ -48,7 +48,7 @@ describe("when specifying credentials flag", () => {
       ),
     );
     const client = new Client({ name: "test client", version: "1.0.0" });
-    const server = await startServer({
+    const server = await createServer({
       credentials: {
         apiKey: "apiKey",
         applicationId: "appId",
@@ -78,7 +78,7 @@ describe("when specifying credentials flag", () => {
       {
         "content": [
           {
-            "text": "{"taskId":123}",
+            "text": "{\"taskId\":123}",
             "type": "text",
           },
         ],
@@ -109,7 +109,7 @@ describe("default behavior", () => {
 
   it("should list dashboard tools", async () => {
     const client = new Client({ name: "test client", version: "1.0.0" });
-    const server = await startServer({});
+    const server = await createServer({});
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
 
@@ -128,7 +128,7 @@ describe("default behavior", () => {
       http.get("https://appid.algolia.net/1/indexes/indexName/settings", () => Response.json({})),
     );
     const client = new Client({ name: "test client", version: "1.0.0" });
-    const server = await startServer({ allowTools: ["getSettings"] });
+    const server = await createServer({ allowTools: ["getSettings"] });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
 

--- a/src/commands/start-server.test.ts
+++ b/src/commands/start-server.test.ts
@@ -74,16 +74,9 @@ describe("when specifying credentials flag", () => {
       },
     });
 
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "content": [
-          {
-            "text": "{\"taskId\":123}",
-            "type": "text",
-          },
-        ],
-      }
-    `);
+    expect(result).toEqual({
+      content: [{ type: "text", text: JSON.stringify({ taskId: 123 }) }],
+    });
 
     await server.close();
   });


### PR DESCRIPTION
Isolates the pre-existing repository-wide test failure seen on PRs #20 and #25.

Root cause:
- `startServer()` creates a `StdioServerTransport` and connects the server before returning it.
- three tests then attempted a second `server.connect()` using `InMemoryTransport`, which the MCP SDK correctly rejects as `Already connected to a transport`.

Fix:
- keep production `startServer()` behavior unchanged
- use the existing unconnected `createServer()` seam only in the three tests that attach their own in-memory transport

Verification on head `2aa2e332465a13ee7dfcac5ded1c4ae5a6e0249d`:
- repository-wide `test`: PASS
- `lint`: PASS
- `type-check`: PASS

No runtime behavior, MCP capabilities, tool registration, credentials, or bridge code is changed.

Dependency note: merge this into `genesis` before finalizing PR #25 so the bridge-hardening branch can inherit a clean repository-wide test baseline.