### PR TITLE
GEN-DEPLOY-005: make Genesis Vercel deployment API-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "lint": "eslint --ext .ts src api",
     "test": "vitest",
     "test:bridge": "vitest run api/registry-bridge.test.ts",
-    "build": "npm run type-check",
     "debug": "mcp-inspector npm start"
   },
   "type": "module",


### PR DESCRIPTION
Fix the Vercel deployment contract exposed by the post-output-directory verification run.

Root cause:
- Vercel auto-detects `npm run build` because `package.json` defines a `build` script.
- That script only runs `tsc --noEmit` and intentionally produces no static artifact.
- Vercel therefore classifies the project as a static build and requires `public`, causing `STATIC_BUILD_NO_OUT_DIR` even with Output Directory set to Auto-detect.

Change:
- remove only the misleading `build` script from `package.json`
- retain `type-check`, `lint`, `test`, and `test:bridge` as the verification gates
- do not create a `public/` directory
- do not change the API functions or Registry bridge code

Expected Vercel behavior after merge to `genesis`: zero-config packaging of the existing `/api` functions without a static output directory.

Production branch tracking is still a separate Vercel dashboard setting and remains `main` until changed to `genesis`.