### PR TITLE
Add governed Synnergyze Program/Event runtime v1

### DIFF
--- a/.github/workflows/program-runtime-test.yml
+++ b/.github/workflows/program-runtime-test.yml
@@ -1,0 +1,36 @@
+name: program-runtime-test
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    paths:
+      - 'api/runtime/**'
+      - '.github/workflows/program-runtime-test.yml'
+  push:
+    branches:
+      - genesis
+    paths:
+      - 'api/runtime/**'
+      - '.github/workflows/program-runtime-test.yml'
+
+jobs:
+  program-runtime:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Run focused Program/Event tests
+        run: npx vitest run api/runtime/program-runner.test.ts
+
+      - name: Type-check API runtime
+        run: npm run -s type-check

--- a/.github/workflows/program-runtime-test.yml
+++ b/.github/workflows/program-runtime-test.yml
@@ -24,10 +24,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          cache: npm
 
-      - name: Install locked dependencies
-        run: npm ci
+      - name: Install dependencies
+        run: npm i
 
       - name: Run focused Program/Event tests
         run: npx vitest run api/runtime/program-runner.test.ts

--- a/api/runtime/program-event-contract.ts
+++ b/api/runtime/program-event-contract.ts
@@ -1,0 +1,206 @@
+export const PROGRAM_EVENT_CONTRACT_VERSION = "synnergyze.program-event.v1" as const;
+
+export type RegistryResolutionStatus =
+  | "RESOLVED"
+  | "UNKNOWN"
+  | "AMBIGUOUS"
+  | "NOT_APPLICABLE"
+  | "REQUIRES_EVIDENCE"
+  | "REQUIRES_AUTHORIZATION"
+  | "DENIED"
+  | "CONFLICT"
+  | "EXPIRED"
+  | "REVOKED"
+  | "SUPERSEDED"
+  | "UNSUPPORTED";
+
+export type ProgramState =
+  | "DRAFT"
+  | "READY_FOR_RESOLUTION"
+  | "BLOCKED_REQUIREMENT"
+  | "READY_FOR_AUTHORIZATION"
+  | "AUTHORIZED"
+  | "RUNNING"
+  | "PAUSED"
+  | "DENIED"
+  | "FAILED"
+  | "EXCEPTION"
+  | "COMPENSATING"
+  | "VERIFIED"
+  | "EFFECT_RECORDED"
+  | "SETTLED_RECONCILED"
+  | "CLOSED"
+  | "SUPERSEDED";
+
+export type EventExecutionState =
+  | "PENDING"
+  | "BLOCKED_REQUIREMENT"
+  | "READY_FOR_AUTHORIZATION"
+  | "DENIED"
+  | "AUTHORIZED"
+  | "EVIDENCE_RESERVED"
+  | "EXECUTED"
+  | "CONFIRMATION_MISMATCH"
+  | "VERIFIED"
+  | "EFFECT_RECORDED"
+  | "SETTLED_RECONCILED"
+  | "EXCEPTION";
+
+export interface ProgramContractV1 {
+  contractVersion: typeof PROGRAM_EVENT_CONTRACT_VERSION;
+  programRef: string;
+  programType: string;
+  version: number;
+  sourceRef: string;
+  ownerContextRef: string;
+  missionPurpose: string;
+  targetOutcomeRefs: string[];
+  contextRefs: string[];
+  participantRoleRefs: string[];
+  dependencyRefs: string[];
+  constraintRefs: string[];
+  authorityRefs: string[];
+  requirementRefs: string[];
+  economicRuleRefs: string[];
+  settlementContextRefs: string[];
+  state: ProgramState;
+  supersedesProgramRef?: string;
+}
+
+export interface EventContractV1 {
+  eventDefinitionRef: string;
+  programRef: string;
+  sequence: number;
+  actorRef: string;
+  actingCapacityRef?: string;
+  placeRef?: string;
+  thingRef: string;
+  requestedCapability: string;
+  dependencyRefs: string[];
+  constraintRefs: string[];
+  authorityRefs: string[];
+  requirementRefs: string[];
+  economicRuleRefs: string[];
+}
+
+export interface RegistryResolutionBundle {
+  requestRef: string;
+  r1: RegistryResolutionStatus;
+  r2: RegistryResolutionStatus;
+  r3: RegistryResolutionStatus;
+  r4: RegistryResolutionStatus;
+  r5: RegistryResolutionStatus;
+  candidateAction?: string;
+  unmetRequirementRefs: string[];
+  authorityRefs: string[];
+  evidenceRequirementRefs: string[];
+  expectedEffectRefs: string[];
+  economicContextRefs: string[];
+}
+
+export interface PreparedProgramAction {
+  correlationId: string;
+  idempotencyKey: string;
+  programRef: string;
+  eventDefinitionRef: string;
+  actorRef: string;
+  actingCapacityRef?: string;
+  targetRef: string;
+  requestedCapability: string;
+  candidateAction: string;
+  authorityRefs: string[];
+  evidenceRequirementRefs: string[];
+}
+
+export interface WardenAuthorizationResult {
+  decisionRef: string;
+  outcome: "AUTHORIZED" | "DENIED" | "REVIEW_REQUIRED";
+  reason?: string;
+}
+
+export interface RiverReservationResult {
+  reservationRef: string;
+  status: "RESERVED" | "UNAVAILABLE";
+  reason?: string;
+}
+
+export interface ExecutionReceipt {
+  receiptRef: string;
+  providerOperationRef?: string;
+}
+
+export interface ConfirmationReceipt {
+  confirmationRef: string;
+  matched: boolean;
+  reason?: string;
+}
+
+export interface RiverSealReceipt {
+  evidenceRef: string;
+}
+
+export interface EffectReceipt {
+  effectRef: string;
+}
+
+export interface EconomicConsequenceReceipt {
+  consequenceRef: string;
+  settlementState: "NOT_REQUIRED" | "PENDING" | "RECONCILED";
+}
+
+export type ProgramTraceStep =
+  | "RESOLVE_R1_R5"
+  | "PREPARE_ACTION"
+  | "WARDEN_AUTHORIZE"
+  | "RIVER_RESERVE"
+  | "EXECUTE_CAPABILITY"
+  | "CONFIRM_RESULT"
+  | "RIVER_SEAL"
+  | "RECORD_EFFECT"
+  | "ECONOMIC_CONSEQUENCE"
+  | "UPDATE_STATE";
+
+export interface ProgramExecutionTraceEntry {
+  step: ProgramTraceStep;
+  state: ProgramState;
+  ref?: string;
+  detail?: string;
+}
+
+export interface ProgramExecutionResult {
+  programRef: string;
+  eventDefinitionRef: string;
+  state: ProgramState;
+  eventState: EventExecutionState;
+  trace: ProgramExecutionTraceEntry[];
+  wardenDecisionRef?: string;
+  evidenceRef?: string;
+  effectRef?: string;
+  economicConsequenceRef?: string;
+  reason?: string;
+}
+
+export interface ProgramExecutionGateway {
+  resolveR1ToR5(program: ProgramContractV1, event: EventContractV1): Promise<RegistryResolutionBundle>;
+  authorize(action: PreparedProgramAction, resolution: RegistryResolutionBundle): Promise<WardenAuthorizationResult>;
+  reserveEvidence(action: PreparedProgramAction, decision: WardenAuthorizationResult): Promise<RiverReservationResult>;
+  executeCapability(action: PreparedProgramAction, reservation: RiverReservationResult): Promise<ExecutionReceipt>;
+  confirmResult(action: PreparedProgramAction, receipt: ExecutionReceipt): Promise<ConfirmationReceipt>;
+  sealEvidence(
+    action: PreparedProgramAction,
+    receipt: ExecutionReceipt,
+    confirmation: ConfirmationReceipt,
+  ): Promise<RiverSealReceipt>;
+  recordEffect(
+    action: PreparedProgramAction,
+    confirmation: ConfirmationReceipt,
+    evidence: RiverSealReceipt,
+    expectedEffectRefs: string[],
+  ): Promise<EffectReceipt>;
+  recordEconomicConsequence(
+    program: ProgramContractV1,
+    event: EventContractV1,
+    effect: EffectReceipt,
+    economicContextRefs: string[],
+  ): Promise<EconomicConsequenceReceipt | null>;
+}

--- a/api/runtime/program-runner.test.ts
+++ b/api/runtime/program-runner.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PROGRAM_EVENT_CONTRACT_VERSION,
+  type EventContractV1,
+  type ProgramContractV1,
+  type ProgramExecutionGateway,
+  type RegistryResolutionBundle,
+} from "./program-event-contract.js";
+import { runProgramEvent } from "./program-runner.js";
+
+function program(): ProgramContractV1 {
+  return {
+    contractVersion: PROGRAM_EVENT_CONTRACT_VERSION,
+    programRef: "program:test:1",
+    programType: "SANDBOX",
+    version: 1,
+    sourceRef: "source:test:1",
+    ownerContextRef: "workspace:test:1",
+    missionPurpose: "Prove governed Program/Event execution",
+    targetOutcomeRefs: ["outcome:test:verified"],
+    contextRefs: ["realm:alpha", "box:test:1"],
+    participantRoleRefs: ["role:test:operator"],
+    dependencyRefs: [],
+    constraintRefs: [],
+    authorityRefs: ["authority:test:program"],
+    requirementRefs: ["requirement:test:evidence"],
+    economicRuleRefs: ["economic:test:rule"],
+    settlementContextRefs: ["settlement:test:1"],
+    state: "DRAFT",
+  };
+}
+
+function event(): EventContractV1 {
+  return {
+    eventDefinitionRef: "event:test:1",
+    programRef: "program:test:1",
+    sequence: 1,
+    actorRef: "digitalme:test:actor",
+    actingCapacityRef: "role:test:operator",
+    placeRef: "place:test:alpha",
+    thingRef: "thing:test:1",
+    requestedCapability: "APPLY",
+    dependencyRefs: [],
+    constraintRefs: [],
+    authorityRefs: ["authority:test:event"],
+    requirementRefs: ["requirement:test:evidence"],
+    economicRuleRefs: ["economic:test:rule"],
+  };
+}
+
+function resolved(): RegistryResolutionBundle {
+  return {
+    requestRef: "registry-request:test:1",
+    r1: "RESOLVED",
+    r2: "RESOLVED",
+    r3: "REQUIRES_AUTHORIZATION",
+    r4: "RESOLVED",
+    r5: "RESOLVED",
+    candidateAction: "ROUTE_TO_TEST_CAPABILITY",
+    unmetRequirementRefs: [],
+    authorityRefs: ["authority:test:registry"],
+    evidenceRequirementRefs: ["requirement:test:evidence"],
+    expectedEffectRefs: ["effect:test:expected"],
+    economicContextRefs: ["economic:test:context"],
+  };
+}
+
+interface GatewayBehavior {
+  resolution?: RegistryResolutionBundle;
+  wardenOutcome?: "AUTHORIZED" | "DENIED" | "REVIEW_REQUIRED";
+  riverAvailable?: boolean;
+  confirmationMatched?: boolean;
+  executionThrows?: boolean;
+  settlementState?: "NOT_REQUIRED" | "PENDING" | "RECONCILED";
+}
+
+function testGateway(behavior: GatewayBehavior = {}) {
+  const calls: string[] = [];
+  const gateway: ProgramExecutionGateway = {
+    async resolveR1ToR5() {
+      calls.push("resolve");
+      return behavior.resolution ?? resolved();
+    },
+    async authorize(action) {
+      calls.push(`authorize:${action.candidateAction}`);
+      return {
+        decisionRef: "warden:test:1",
+        outcome: behavior.wardenOutcome ?? "AUTHORIZED",
+        reason: behavior.wardenOutcome === "DENIED" ? "policy_denied" : undefined,
+      };
+    },
+    async reserveEvidence() {
+      calls.push("reserve");
+      return behavior.riverAvailable === false
+        ? { reservationRef: "river-reservation:test:1", status: "UNAVAILABLE", reason: "river_down" }
+        : { reservationRef: "river-reservation:test:1", status: "RESERVED" };
+    },
+    async executeCapability() {
+      calls.push("execute");
+      if (behavior.executionThrows) throw new Error("connector_timeout");
+      return { receiptRef: "provider-receipt:test:1" };
+    },
+    async confirmResult() {
+      calls.push("confirm");
+      return {
+        confirmationRef: "confirmation:test:1",
+        matched: behavior.confirmationMatched ?? true,
+        reason: behavior.confirmationMatched === false ? "state_mismatch" : undefined,
+      };
+    },
+    async sealEvidence() {
+      calls.push("seal");
+      return { evidenceRef: "river-evidence:test:1" };
+    },
+    async recordEffect() {
+      calls.push("effect");
+      return { effectRef: "effect:test:1" };
+    },
+    async recordEconomicConsequence() {
+      calls.push("economic");
+      return {
+        consequenceRef: "economic-consequence:test:1",
+        settlementState: behavior.settlementState ?? "RECONCILED",
+      };
+    },
+  };
+
+  return { gateway, calls };
+}
+
+const input = () => ({
+  program: program(),
+  event: event(),
+  correlationId: "corr:test:1",
+  idempotencyKey: "idem:test:1",
+});
+
+describe("Synnergyze Program/Event runtime v1", () => {
+  it("executes the governed happy path in canonical order", async () => {
+    const { gateway, calls } = testGateway();
+    const output = await runProgramEvent(input(), gateway);
+
+    expect(output.state).toBe("SETTLED_RECONCILED");
+    expect(output.eventState).toBe("SETTLED_RECONCILED");
+    expect(output.wardenDecisionRef).toBe("warden:test:1");
+    expect(output.evidenceRef).toBe("river-evidence:test:1");
+    expect(output.effectRef).toBe("effect:test:1");
+    expect(output.economicConsequenceRef).toBe("economic-consequence:test:1");
+    expect(calls).toEqual([
+      "resolve",
+      "authorize:ROUTE_TO_TEST_CAPABILITY",
+      "reserve",
+      "execute",
+      "confirm",
+      "seal",
+      "effect",
+      "economic",
+    ]);
+    expect(output.trace.map((entry) => entry.step)).toEqual([
+      "RESOLVE_R1_R5",
+      "PREPARE_ACTION",
+      "WARDEN_AUTHORIZE",
+      "RIVER_RESERVE",
+      "EXECUTE_CAPABILITY",
+      "CONFIRM_RESULT",
+      "RIVER_SEAL",
+      "RECORD_EFFECT",
+      "ECONOMIC_CONSEQUENCE",
+      "UPDATE_STATE",
+    ]);
+  });
+
+  it("blocks unmet R4 requirements before Warden or execution", async () => {
+    const blockedResolution = resolved();
+    blockedResolution.r4 = "REQUIRES_EVIDENCE";
+    blockedResolution.unmetRequirementRefs = ["requirement:test:missing"];
+    const { gateway, calls } = testGateway({ resolution: blockedResolution });
+
+    const output = await runProgramEvent(input(), gateway);
+
+    expect(output.state).toBe("BLOCKED_REQUIREMENT");
+    expect(output.eventState).toBe("BLOCKED_REQUIREMENT");
+    expect(output.reason).toContain("requirement:test:missing");
+    expect(calls).toEqual(["resolve"]);
+  });
+
+  it("treats R5 as routing only and stops on Warden denial", async () => {
+    const { gateway, calls } = testGateway({ wardenOutcome: "DENIED" });
+
+    const output = await runProgramEvent(input(), gateway);
+
+    expect(output.state).toBe("DENIED");
+    expect(output.wardenDecisionRef).toBe("warden:test:1");
+    expect(calls).toEqual(["resolve", "authorize:ROUTE_TO_TEST_CAPABILITY"]);
+    expect(calls).not.toContain("execute");
+  });
+
+  it("blocks execution when River evidence cannot be reserved", async () => {
+    const { gateway, calls } = testGateway({ riverAvailable: false });
+
+    const output = await runProgramEvent(input(), gateway);
+
+    expect(output.state).toBe("BLOCKED_REQUIREMENT");
+    expect(output.reason).toBe("river_down");
+    expect(calls).toEqual(["resolve", "authorize:ROUTE_TO_TEST_CAPABILITY", "reserve"]);
+  });
+
+  it("records confirmation mismatch evidence but creates no Effect or economics", async () => {
+    const { gateway, calls } = testGateway({ confirmationMatched: false });
+
+    const output = await runProgramEvent(input(), gateway);
+
+    expect(output.state).toBe("EXCEPTION");
+    expect(output.eventState).toBe("CONFIRMATION_MISMATCH");
+    expect(output.evidenceRef).toBe("river-evidence:test:1");
+    expect(output.effectRef).toBeUndefined();
+    expect(calls).toEqual([
+      "resolve",
+      "authorize:ROUTE_TO_TEST_CAPABILITY",
+      "reserve",
+      "execute",
+      "confirm",
+      "seal",
+    ]);
+  });
+
+  it("routes connector failure to EXCEPTION before confirmation or Effect", async () => {
+    const { gateway, calls } = testGateway({ executionThrows: true });
+
+    const output = await runProgramEvent(input(), gateway);
+
+    expect(output.state).toBe("EXCEPTION");
+    expect(output.reason).toBe("connector_timeout");
+    expect(calls).toEqual([
+      "resolve",
+      "authorize:ROUTE_TO_TEST_CAPABILITY",
+      "reserve",
+      "execute",
+    ]);
+  });
+});

--- a/api/runtime/program-runner.test.ts
+++ b/api/runtime/program-runner.test.ts
@@ -174,6 +174,8 @@ describe("Synnergyze Program/Event runtime v1", () => {
   it("blocks unmet R4 requirements before Warden or execution", async () => {
     const blockedResolution = resolved();
     blockedResolution.r4 = "REQUIRES_EVIDENCE";
+    blockedResolution.r5 = "REQUIRES_EVIDENCE";
+    delete blockedResolution.candidateAction;
     blockedResolution.unmetRequirementRefs = ["requirement:test:missing"];
     const { gateway, calls } = testGateway({ resolution: blockedResolution });
 
@@ -208,7 +210,6 @@ describe("Synnergyze Program/Event runtime v1", () => {
 
   it("records confirmation mismatch evidence but creates no Effect or economics", async () => {
     const { gateway, calls } = testGateway({ confirmationMatched: false });
-
     const output = await runProgramEvent(input(), gateway);
 
     expect(output.state).toBe("EXCEPTION");
@@ -227,7 +228,6 @@ describe("Synnergyze Program/Event runtime v1", () => {
 
   it("routes connector failure to EXCEPTION before confirmation or Effect", async () => {
     const { gateway, calls } = testGateway({ executionThrows: true });
-
     const output = await runProgramEvent(input(), gateway);
 
     expect(output.state).toBe("EXCEPTION");

--- a/api/runtime/program-runner.ts
+++ b/api/runtime/program-runner.ts
@@ -45,7 +45,6 @@ function resolutionFailure(resolution: RegistryResolutionBundle): string | null 
   if (resolution.r3 !== "RESOLVED" && resolution.r3 !== "REQUIRES_AUTHORIZATION") {
     return `R3_${resolution.r3}`;
   }
-  if (resolution.r5 !== "RESOLVED" || !resolution.candidateAction) return `R5_${resolution.r5}`;
   return null;
 }
 
@@ -92,6 +91,12 @@ export async function runProgramEvent(
     });
   }
 
+  if (resolution.r5 !== "RESOLVED" || !resolution.candidateAction) {
+    return result(program, event, "EXCEPTION", "EXCEPTION", entries, {
+      reason: `R5_${resolution.r5}`,
+    });
+  }
+
   const action: PreparedProgramAction = {
     correlationId,
     idempotencyKey,
@@ -101,7 +106,7 @@ export async function runProgramEvent(
     actingCapacityRef: event.actingCapacityRef,
     targetRef: event.thingRef,
     requestedCapability: event.requestedCapability,
-    candidateAction: resolution.candidateAction!,
+    candidateAction: resolution.candidateAction,
     authorityRefs: [...new Set([...event.authorityRefs, ...resolution.authorityRefs])],
     evidenceRequirementRefs: [
       ...new Set([...event.requirementRefs, ...resolution.evidenceRequirementRefs]),

--- a/api/runtime/program-runner.ts
+++ b/api/runtime/program-runner.ts
@@ -1,0 +1,190 @@
+import type {
+  EventContractV1,
+  EventExecutionState,
+  PreparedProgramAction,
+  ProgramContractV1,
+  ProgramExecutionGateway,
+  ProgramExecutionResult,
+  ProgramExecutionTraceEntry,
+  ProgramState,
+  RegistryResolutionBundle,
+} from "./program-event-contract.js";
+
+function trace(
+  entries: ProgramExecutionTraceEntry[],
+  step: ProgramExecutionTraceEntry["step"],
+  state: ProgramState,
+  ref?: string,
+  detail?: string,
+) {
+  entries.push({ step, state, ref, detail });
+}
+
+function result(
+  program: ProgramContractV1,
+  event: EventContractV1,
+  state: ProgramState,
+  eventState: EventExecutionState,
+  entries: ProgramExecutionTraceEntry[],
+  extra: Omit<ProgramExecutionResult, "programRef" | "eventDefinitionRef" | "state" | "eventState" | "trace"> = {},
+): ProgramExecutionResult {
+  return {
+    programRef: program.programRef,
+    eventDefinitionRef: event.eventDefinitionRef,
+    state,
+    eventState,
+    trace: entries,
+    ...extra,
+  };
+}
+
+function resolutionFailure(resolution: RegistryResolutionBundle): string | null {
+  if (resolution.r1 !== "RESOLVED") return `R1_${resolution.r1}`;
+  if (resolution.r2 !== "RESOLVED") return `R2_${resolution.r2}`;
+  if (["DENIED", "EXPIRED", "REVOKED"].includes(resolution.r3)) return `R3_${resolution.r3}`;
+  if (resolution.r3 !== "RESOLVED" && resolution.r3 !== "REQUIRES_AUTHORIZATION") {
+    return `R3_${resolution.r3}`;
+  }
+  if (resolution.r5 !== "RESOLVED" || !resolution.candidateAction) return `R5_${resolution.r5}`;
+  return null;
+}
+
+export interface RunProgramEventInput {
+  program: ProgramContractV1;
+  event: EventContractV1;
+  correlationId: string;
+  idempotencyKey: string;
+}
+
+export async function runProgramEvent(
+  input: RunProgramEventInput,
+  gateway: ProgramExecutionGateway,
+): Promise<ProgramExecutionResult> {
+  const { program, event, correlationId, idempotencyKey } = input;
+  const entries: ProgramExecutionTraceEntry[] = [];
+
+  if (event.programRef !== program.programRef) {
+    return result(program, event, "EXCEPTION", "EXCEPTION", entries, {
+      reason: "EVENT_PROGRAM_REF_MISMATCH",
+    });
+  }
+
+  trace(entries, "RESOLVE_R1_R5", "READY_FOR_RESOLUTION");
+  const resolution = await gateway.resolveR1ToR5(program, event);
+  const failedResolution = resolutionFailure(resolution);
+  if (failedResolution) {
+    const denied = failedResolution.startsWith("R3_DENIED") || failedResolution.startsWith("R3_EXPIRED") || failedResolution.startsWith("R3_REVOKED");
+    return result(program, event, denied ? "DENIED" : "EXCEPTION", denied ? "DENIED" : "EXCEPTION", entries, {
+      reason: failedResolution,
+    });
+  }
+
+  if (resolution.r4 === "REQUIRES_EVIDENCE" || resolution.unmetRequirementRefs.length > 0) {
+    return result(program, event, "BLOCKED_REQUIREMENT", "BLOCKED_REQUIREMENT", entries, {
+      reason: resolution.unmetRequirementRefs.length
+        ? `UNMET_REQUIREMENTS:${resolution.unmetRequirementRefs.join(",")}`
+        : "R4_REQUIRES_EVIDENCE",
+    });
+  }
+  if (resolution.r4 !== "RESOLVED") {
+    return result(program, event, "BLOCKED_REQUIREMENT", "BLOCKED_REQUIREMENT", entries, {
+      reason: `R4_${resolution.r4}`,
+    });
+  }
+
+  const action: PreparedProgramAction = {
+    correlationId,
+    idempotencyKey,
+    programRef: program.programRef,
+    eventDefinitionRef: event.eventDefinitionRef,
+    actorRef: event.actorRef,
+    actingCapacityRef: event.actingCapacityRef,
+    targetRef: event.thingRef,
+    requestedCapability: event.requestedCapability,
+    candidateAction: resolution.candidateAction!,
+    authorityRefs: [...new Set([...event.authorityRefs, ...resolution.authorityRefs])],
+    evidenceRequirementRefs: [
+      ...new Set([...event.requirementRefs, ...resolution.evidenceRequirementRefs]),
+    ],
+  };
+
+  trace(entries, "PREPARE_ACTION", "READY_FOR_AUTHORIZATION", undefined, action.candidateAction);
+  trace(entries, "WARDEN_AUTHORIZE", "READY_FOR_AUTHORIZATION");
+  const decision = await gateway.authorize(action, resolution);
+  if (decision.outcome !== "AUTHORIZED") {
+    const paused = decision.outcome === "REVIEW_REQUIRED";
+    return result(program, event, paused ? "PAUSED" : "DENIED", paused ? "READY_FOR_AUTHORIZATION" : "DENIED", entries, {
+      wardenDecisionRef: decision.decisionRef,
+      reason: decision.reason ?? `WARDEN_${decision.outcome}`,
+    });
+  }
+
+  trace(entries, "RIVER_RESERVE", "AUTHORIZED", decision.decisionRef);
+  const reservation = await gateway.reserveEvidence(action, decision);
+  if (reservation.status !== "RESERVED") {
+    return result(program, event, "BLOCKED_REQUIREMENT", "BLOCKED_REQUIREMENT", entries, {
+      wardenDecisionRef: decision.decisionRef,
+      reason: reservation.reason ?? "RIVER_EVIDENCE_UNAVAILABLE",
+    });
+  }
+
+  let execution;
+  try {
+    trace(entries, "EXECUTE_CAPABILITY", "RUNNING", reservation.reservationRef);
+    execution = await gateway.executeCapability(action, reservation);
+  } catch (error) {
+    return result(program, event, "EXCEPTION", "EXCEPTION", entries, {
+      wardenDecisionRef: decision.decisionRef,
+      reason: error instanceof Error ? error.message : "EXECUTION_FAILED",
+    });
+  }
+
+  trace(entries, "CONFIRM_RESULT", "RUNNING", execution.receiptRef);
+  const confirmation = await gateway.confirmResult(action, execution);
+  if (!confirmation.matched) {
+    trace(entries, "RIVER_SEAL", "EXCEPTION", confirmation.confirmationRef, "confirmation_mismatch");
+    const mismatchEvidence = await gateway.sealEvidence(action, execution, confirmation);
+    return result(program, event, "EXCEPTION", "CONFIRMATION_MISMATCH", entries, {
+      wardenDecisionRef: decision.decisionRef,
+      evidenceRef: mismatchEvidence.evidenceRef,
+      reason: confirmation.reason ?? "CONFIRMATION_MISMATCH",
+    });
+  }
+
+  trace(entries, "RIVER_SEAL", "VERIFIED", confirmation.confirmationRef);
+  const evidence = await gateway.sealEvidence(action, execution, confirmation);
+
+  trace(entries, "RECORD_EFFECT", "VERIFIED", evidence.evidenceRef);
+  const effect = await gateway.recordEffect(
+    action,
+    confirmation,
+    evidence,
+    resolution.expectedEffectRefs,
+  );
+
+  trace(entries, "ECONOMIC_CONSEQUENCE", "EFFECT_RECORDED", effect.effectRef);
+  const economic = await gateway.recordEconomicConsequence(
+    program,
+    event,
+    effect,
+    resolution.economicContextRefs,
+  );
+
+  const finalState: ProgramState =
+    economic?.settlementState === "RECONCILED" ? "SETTLED_RECONCILED" : "EFFECT_RECORDED";
+  trace(entries, "UPDATE_STATE", finalState, economic?.consequenceRef ?? effect.effectRef);
+
+  return result(
+    program,
+    event,
+    finalState,
+    economic?.settlementState === "RECONCILED" ? "SETTLED_RECONCILED" : "EFFECT_RECORDED",
+    entries,
+    {
+      wardenDecisionRef: decision.decisionRef,
+      evidenceRef: evidence.evidenceRef,
+      effectRef: effect.effectRef,
+      economicConsequenceRef: economic?.consequenceRef,
+    },
+  );
+}


### PR DESCRIPTION
## Objective

Implements the first synthetic/sandbox slice for `Believers-common-group/SynergyzeGovernance#13` on the governed Synnergyze runtime branch.

This PR adds orchestration only. It does **not** redefine Registry R1–R5, Warden authority, RiverOS evidence truth, SILK/EMR settlement authority, DigitalMe identity, or provider persistence semantics.

## Added

- `api/runtime/program-event-contract.ts`
  - versioned Program and Event contracts;
  - explicit Program/Event lifecycle states;
  - R1–R5 resolution bundle;
  - injected gateway interfaces for Registry, Warden, River, connector execution, Effect and economic consequence;
  - ordered execution trace vocabulary.
- `api/runtime/program-runner.ts`
  - R1–R5 resolution;
  - explicit R4 requirement blocking;
  - R5 route preparation without authority grant;
  - Warden authorization before any execution;
  - River evidence reservation before connector execution;
  - confirmation before verified Effect;
  - evidence sealing for both successful and mismatched confirmation;
  - economic consequence only after verified Effect;
  - explicit DENIED / PAUSED / BLOCKED_REQUIREMENT / EXCEPTION / EFFECT_RECORDED / SETTLED_RECONCILED states.
- `api/runtime/program-runner.test.ts`
  - governed happy path;
  - unmet R4 requirement;
  - Warden denial proving `R5 ≠ authorization`;
  - River evidence unavailable;
  - read-after-write/confirmation mismatch;
  - connector failure before Effect.
- `.github/workflows/program-runtime-test.yml`
  - focused Program/Event Vitest gate;
  - API type-check.

## Canonical order

`RESOLVE R1–R5 → PREPARE → WARDEN AUTHORIZE → RIVER RESERVE → EXECUTE → CONFIRM → RIVER SEAL → EFFECT → ECONOMIC CONSEQUENCE → UPDATE STATE`

## Safety boundary

- no live database credentials;
- no production provider writes;
- no autonomous authority or settlement;
- no connector execution before Warden authorization + evidence readiness;
- confirmation mismatch creates evidence/exception but no Effect or economic consequence.

## Dependencies

- `Believers-common-group/SynergyzeGovernance#11` — Registry R1–R5 contracts;
- `Believers-common-group/SynergyzeGovernance#5` — BOX/Arc containment;
- `Believers-common-group/SynergyzeGovernance#12` — persistence/evidence boundary;
- `Believers-common-group/Virtual-Silk-road#16` — draft machine-readable Registry contract v1;
- `Esomoire-consultancy-Company/virtual-silk-road-platform#127` — draft provider-neutral persistence/evidence runtime.

This remains synthetic until the upstream contracts are accepted and provider adapters are separately authorized.

Related: `Believers-common-group/SynergyzeGovernance#10`, `#13`, `#16`.