### PR TITLE
ALPHA-VERCEL-PRIVATE-MOUNT-001: private Alpha mount probe

### DIFF
--- a/docs/alpha-node/ALPHA-VERCEL-PRIVATE-MOUNT-001.md
+++ b/docs/alpha-node/ALPHA-VERCEL-PRIVATE-MOUNT-001.md
@@ -1,0 +1,138 @@
+# ALPHA-VERCEL-PRIVATE-MOUNT-001
+
+**Scope root:** `ALPHA-NODE-001`  
+**State:** `DRAFT_PRIVATE_MOUNT_CONTRACT`  
+**Service:** `synnergyze-genesis-mcp`  
+**Canonical source branch:** `genesis`
+
+## Purpose
+
+Mount the Vercel-hosted Synnergyze Genesis MCP boundary into `ALPHA-NODE-001` without making the deployment public and without treating Vercel authentication as Registry or Warden authority.
+
+The mount is an Alpha edge/runtime connector. It does not replace the Alpha Registry, Genesis identity resolution, Warden authorization, RiverOS evidence, or Synnergyze governed execution semantics.
+
+## Authentication layers
+
+The private mount uses independent credentials for independent boundaries.
+
+1. **Vercel edge access** — `VERCEL_AUTOMATION_BYPASS_SECRET`
+   - Sent only in the `x-vercel-protection-bypass` request header.
+   - Allows the Alpha probe/runtime to pass Vercel Deployment Protection.
+   - Must not be placed in URLs, logs, source code, Registry payloads, DigitalMe projections, or River evidence bodies.
+   - Does **not** grant access to Registry bridge operations by itself.
+
+2. **Registry bridge service authorization** — `REGISTRY_BRIDGE_SECRET`
+   - Sent as `Authorization: Bearer ...` only when the bridge is intentionally executed.
+   - Separate from the Vercel bypass secret.
+   - The safe probe never sends it unless `ALPHA_RUN_REGISTRY_BRIDGE=1` is explicitly set.
+
+3. **Warden authority** — independent governed decision
+   - Neither Vercel bypass nor bridge bearer is a Warden decision.
+   - Edge/service authentication cannot manufacture participant authority, consent, licence, mandate, or Registry effect.
+
+Canonical invariant:
+
+```text
+VERCEL_EDGE_ACCESS != SERVICE_AUTHORIZATION != WARDEN_AUTHORITY != REGISTRY_EFFECT
+```
+
+## Current Vercel service contract
+
+The `genesis` branch defines an API-only deployment with these governed routes:
+
+```text
+/health           -> /api/health
+/mcp              -> /api/mcp
+/registry-bridge  -> /api/registry-bridge
+```
+
+The deployment must remain API-only (`framework: null`, no static output directory).
+
+## Mount states
+
+```text
+BUILD_READY
+   ↓
+EDGE_PROTECTED
+   ↓ generate/bind scoped Vercel automation bypass
+EDGE_REACHABLE
+   ↓
+HEALTH_VERIFIED
+   ↓
+MCP_VERIFIED
+   ↓
+BRIDGE_DEFAULT_DENY_VERIFIED
+   ↓ explicit Warden/operator execution envelope if bridge mutation is required
+BRIDGE_AUTHORIZED_TEST
+   ↓ River/Registry evidence
+ALPHA_PRIVATE_MOUNT_READY
+```
+
+`BUILD_READY` does not imply `EDGE_REACHABLE`.  
+`EDGE_REACHABLE` does not imply `MCP_VERIFIED`.  
+`MCP_VERIFIED` does not authorize Registry bridge execution.  
+`REGISTRY_BRIDGE_SECRET` does not replace Warden authority.
+
+## Safe acceptance probe
+
+Run from an Alpha-controlled environment or authorized operator shell:
+
+```bash
+export ALPHA_VERCEL_BASE_URL='https://<protected-genesis-alias>'
+export VERCEL_AUTOMATION_BYPASS_SECRET='<secret-from-vercel-project-protection>'
+
+node scripts/alpha-vercel-private-probe.mjs
+```
+
+Default probe behavior:
+
+1. `GET /health` must return `200` and identify `synnergyze-genesis-mcp`.
+2. `GET /mcp` must reach the application and return governed `405` (`POST` required).
+3. `POST /mcp` performs a Streamable HTTP MCP initialize request and must return the expected server identity.
+4. `GET /registry-bridge?limit=1` **without** a bearer must return `401 unauthorized`.
+5. Authorized bridge execution is skipped.
+
+The default probe is therefore non-bridge-mutating.
+
+## Explicit bridge execution
+
+The Registry bridge claims/leases outbox rows and may deliver events. It is a mutating operation even when invoked with HTTP `GET`.
+
+Run only inside an explicit execution envelope:
+
+```bash
+export REGISTRY_BRIDGE_SECRET='<bridge-secret>'
+export ALPHA_RUN_REGISTRY_BRIDGE=1
+node scripts/alpha-vercel-private-probe.mjs
+```
+
+The probe constrains the bridge test to `limit=1` and expects the governed bridge identity `GEN-PART-PG-BRIDGE-003` with source `CWR-REGISTRY`.
+
+Do not set `ALPHA_RUN_REGISTRY_BRIDGE=1` merely to test connectivity.
+
+## Secret custody
+
+For Alpha:
+
+- Store the Vercel automation bypass secret in an Alpha secret store / operator environment, not source.
+- Use a project/environment-scoped secret, rotate independently of the bridge credential.
+- Never reuse DigitalMe, Warden, Registry database, Supabase service-role, or Alpha bootstrap credentials as the Vercel bypass secret.
+- Prefer the HTTP header form over a query parameter to reduce accidental logging.
+- Revoke/rotate the bypass when an Alpha mount is retired or superseded.
+
+## Production promotion
+
+The initial Alpha private mount may target a stable `genesis` branch alias while the project remains non-live. Production alias assignment is a separate state transition and must not be inferred from a READY preview deployment.
+
+Promotion criteria include:
+
+- private probe passes;
+- required Vercel/Supabase/bridge environment variables are confirmed without exposing values;
+- focused repository tests/CI are green or independently reproduced;
+- dependency/security gate is dispositioned;
+- production branch/routing is explicitly set to the intended `genesis` lineage;
+- Warden/River/Registry edge-effect acceptance is completed.
+
+## Alpha boundary
+
+This document and probe are scoped only to `ALPHA-NODE-001`. Any future BNR-node reuse must be issued as a new version/object with its own authority, credentials, node identity, environment and evidence lineage.

--- a/scripts/alpha-vercel-private-probe.mjs
+++ b/scripts/alpha-vercel-private-probe.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+const BASE_URL = process.env.ALPHA_VERCEL_BASE_URL?.replace(/\/$/, "");
+const BYPASS_SECRET = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+const RUN_BRIDGE = process.env.ALPHA_RUN_REGISTRY_BRIDGE === "1";
+const BRIDGE_SECRET = process.env.REGISTRY_BRIDGE_SECRET;
+
+function fail(message) {
+  console.error(`ALPHA_VERCEL_PROBE_FAIL: ${message}`);
+  process.exitCode = 1;
+}
+
+function requireConfig() {
+  const missing = [];
+  if (!BASE_URL) missing.push("ALPHA_VERCEL_BASE_URL");
+  if (!BYPASS_SECRET) missing.push("VERCEL_AUTOMATION_BYPASS_SECRET");
+  if (RUN_BRIDGE && !BRIDGE_SECRET) missing.push("REGISTRY_BRIDGE_SECRET");
+  if (missing.length) {
+    throw new Error(`Missing required environment: ${missing.join(", ")}`);
+  }
+}
+
+function edgeHeaders(extra = {}) {
+  return {
+    "x-vercel-protection-bypass": BYPASS_SECRET,
+    ...extra,
+  };
+}
+
+async function request(path, options = {}) {
+  const response = await fetch(`${BASE_URL}${path}`, {
+    ...options,
+    headers: edgeHeaders(options.headers ?? {}),
+    signal: AbortSignal.timeout(10_000),
+    redirect: "manual",
+  });
+  const text = await response.text();
+  let json;
+  try {
+    json = text ? JSON.parse(text) : undefined;
+  } catch {
+    json = undefined;
+  }
+  return { response, text, json };
+}
+
+async function checkHealth() {
+  const { response, json, text } = await request("/health", {
+    headers: { accept: "application/json" },
+  });
+
+  if (response.status !== 200) {
+    throw new Error(`/health expected 200, got ${response.status}: ${text.slice(0, 300)}`);
+  }
+  if (json?.ok !== true || json?.service !== "synnergyze-genesis-mcp") {
+    throw new Error(`/health returned unexpected body: ${text.slice(0, 300)}`);
+  }
+
+  console.log("PASS health: private Vercel edge reached service runtime");
+}
+
+async function checkMcpMethodBoundary() {
+  const { response, json, text } = await request("/mcp", {
+    method: "GET",
+    headers: { accept: "application/json" },
+  });
+
+  if (response.status !== 405 || json?.error !== "Use POST for MCP requests.") {
+    throw new Error(`/mcp GET expected governed 405, got ${response.status}: ${text.slice(0, 300)}`);
+  }
+
+  console.log("PASS mcp-method: route reached application boundary");
+}
+
+async function checkMcpInitialize() {
+  const body = {
+    jsonrpc: "2.0",
+    id: "alpha-vercel-probe:init",
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: {
+        name: "alpha-vercel-private-probe",
+        version: "1.0.0",
+      },
+    },
+  };
+
+  const { response, json, text } = await request("/mcp", {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (response.status !== 200) {
+    throw new Error(`/mcp initialize expected 200, got ${response.status}: ${text.slice(0, 500)}`);
+  }
+  if (json?.jsonrpc !== "2.0" || json?.result?.serverInfo?.name !== "synnergyze-genesis-mcp") {
+    throw new Error(`/mcp initialize returned unexpected response: ${text.slice(0, 500)}`);
+  }
+
+  console.log("PASS mcp-initialize: Streamable HTTP MCP boundary initialized");
+}
+
+async function checkBridgeDefaultDeny() {
+  const { response, json, text } = await request("/registry-bridge?limit=1", {
+    method: "GET",
+    headers: { accept: "application/json" },
+  });
+
+  if (response.status !== 401 || json?.error !== "unauthorized") {
+    throw new Error(`/registry-bridge without bearer expected 401, got ${response.status}: ${text.slice(0, 300)}`);
+  }
+
+  console.log("PASS bridge-default-deny: Vercel bypass does not bypass bridge authorization");
+}
+
+async function runAuthorizedBridge() {
+  if (!RUN_BRIDGE) {
+    console.log("SKIP bridge-authorized: set ALPHA_RUN_REGISTRY_BRIDGE=1 for explicit mutating bridge execution");
+    return;
+  }
+
+  const { response, json, text } = await request("/registry-bridge?limit=1", {
+    method: "GET",
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${BRIDGE_SECRET}`,
+    },
+  });
+
+  if (![200, 207].includes(response.status)) {
+    throw new Error(`/registry-bridge authorized expected 200/207, got ${response.status}: ${text.slice(0, 500)}`);
+  }
+  if (json?.bridge !== "GEN-PART-PG-BRIDGE-003" || json?.source !== "CWR-REGISTRY") {
+    throw new Error(`/registry-bridge returned unexpected governed bridge identity: ${text.slice(0, 500)}`);
+  }
+
+  console.log(
+    `PASS bridge-authorized: scanned=${json.scanned ?? "?"} delivered=${json.delivered ?? "?"} failed=${json.failed ?? "?"}`,
+  );
+}
+
+async function main() {
+  requireConfig();
+
+  console.log("ALPHA-NODE-001 private Vercel mount probe");
+  console.log(`target=${new URL(BASE_URL).host}`);
+  console.log("invariant: Vercel bypass authenticates edge access only; it grants no Registry/Warden authority");
+
+  await checkHealth();
+  await checkMcpMethodBoundary();
+  await checkMcpInitialize();
+  await checkBridgeDefaultDeny();
+  await runAuthorizedBridge();
+
+  console.log("ALPHA_VERCEL_PROBE_PASS");
+}
+
+main().catch((error) => {
+  fail(error instanceof Error ? error.message : String(error));
+});


### PR DESCRIPTION
## Alpha scope

`scope_root: ALPHA-NODE-001`

This draft adds the private Vercel mount acceptance contract for the READY `synnergyze-genesis-mcp` API-only service. It does not promote production, disable Vercel Deployment Protection, add secrets, run the Registry bridge, or confer Warden authority.

## Added

- `docs/alpha-node/ALPHA-VERCEL-PRIVATE-MOUNT-001.md`
- `scripts/alpha-vercel-private-probe.mjs`

## Authentication separation

```text
VERCEL_EDGE_ACCESS != SERVICE_AUTHORIZATION != WARDEN_AUTHORITY != REGISTRY_EFFECT
```

The mount uses Vercel Protection Bypass for Automation (`x-vercel-protection-bypass`) to keep the service private. Registry bridge authorization remains a separate bearer credential. Neither credential is treated as a Warden decision.

## Safe default probe

Without any bridge execution flag, the script verifies:

1. `/health` reaches the private service and returns the expected service identity;
2. `GET /mcp` reaches the application method boundary and returns 405;
3. `POST /mcp` initializes the Streamable HTTP MCP endpoint;
4. `/registry-bridge?limit=1` without a bearer remains `401 unauthorized`;
5. authorized bridge execution is skipped.

The bridge is invoked only when `ALPHA_RUN_REGISTRY_BRIDGE=1` **and** `REGISTRY_BRIDGE_SECRET` are explicitly present. That path is mutating and is not executed by this PR.

## Current prerequisite

Generate/bind a project-scoped `VERCEL_AUTOMATION_BYPASS_SECRET` in Vercel Deployment Protection and provide it only to the Alpha-controlled probe/runtime environment. Do not commit or log the value.

## Boundary

This is Alpha-only. Future BNR nodes must receive their own mount object, credentials, authority and evidence lineage.