### PR TITLE
P4: add release-train temporal engine adapter

### DIFF
--- a/.github/workflows/p4-release-train-adapter-test.yml
+++ b/.github/workflows/p4-release-train-adapter-test.yml
@@ -1,0 +1,30 @@
+name: p4-release-train-adapter-test
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    paths:
+      - 'api/adapters/**'
+      - 'api/runtime/**'
+      - '.github/workflows/p4-release-train-adapter-test.yml'
+
+jobs:
+  release-train-adapter:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Run focused release train adapter tests
+        run: npx vitest run api/adapters/release-train-adapter.test.ts
+
+      - name: Type-check API runtime and adapters
+        run: npm run -s type-check

--- a/api/adapters/release-train-adapter.test.ts
+++ b/api/adapters/release-train-adapter.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+
+import { runProgramEvent } from "../runtime/program-runner.js";
+import type { ProgramExecutionGateway, RegistryResolutionBundle } from "../runtime/program-event-contract.js";
+import { unresolvedGovernanceFields } from "./source-adapter-contract.js";
+import {
+  adaptReleaseTrainMilestone,
+  applyReleaseTrainGovernanceOverlay,
+  generateDateFromReleaseAnchor,
+} from "./release-train-adapter.js";
+
+const VERIFIED_SOURCE_SHA256 = "1bb907613dfbd185cf208df636c900f4f824420e0a3dc735084a67cdb61f6674";
+
+function v49VettingSource() {
+  return adaptReleaseTrainMilestone({
+    locator: {
+      fileName: "CLDR + ICU detailed schedule.xlsx",
+      fileSha256: VERIFIED_SOURCE_SHA256,
+      sheetName: "coordinated",
+      cellAddress: "C269",
+      sourceRow: 269,
+      sourceColumn: "C",
+    },
+    stream: "CLDR",
+    releaseVersion: "v49",
+    sourceDate: "2026-06-17",
+    milestoneText: "v49 Start Vetting",
+    durationWeeks: 2.75,
+    sourceRemainingWeeks: 20,
+    anchor: {
+      locator: {
+        fileName: "CLDR + ICU detailed schedule.xlsx",
+        fileSha256: VERIFIED_SOURCE_SHA256,
+        sheetName: "coordinated",
+        cellAddress: "C281",
+        sourceRow: 281,
+        sourceColumn: "C",
+      },
+      releaseVersion: "v49",
+      releaseDate: "2026-10-21",
+      rawValue: "v49 Release",
+    },
+  });
+}
+
+function governedV49Vetting() {
+  return applyReleaseTrainGovernanceOverlay(v49VettingSource(), {
+    ownerRoleRef: "role:sandbox:release-manager",
+    authorityRefs: ["authority:sandbox:release-gate"],
+    evidenceRequirementRefs: ["requirement:sandbox:vetting-evidence"],
+    dependencyRefs: ["program-dependency:sandbox:submission-complete"],
+    constraintRefs: ["constraint:sandbox:no-production-release"],
+    targetStateRef: "state:sandbox:vetting-started",
+    closureConditionRef: "closure:sandbox:vetting-gate-evidence-confirmed",
+    r5CandidateRoute: "route:sandbox:start-vetting",
+  });
+}
+
+function gatewayFor(item: ReturnType<typeof governedV49Vetting>) {
+  const calls: string[] = [];
+  const resolution: RegistryResolutionBundle = {
+    requestRef: "registry-request:sandbox:v49-vetting",
+    r1: "RESOLVED",
+    r2: "RESOLVED",
+    r3: "REQUIRES_AUTHORIZATION",
+    r4: "RESOLVED",
+    r5: "RESOLVED",
+    candidateAction: item.r5CandidateRoute,
+    unmetRequirementRefs: [],
+    authorityRefs: item.event.authorityRefs,
+    evidenceRequirementRefs: item.event.requirementRefs,
+    expectedEffectRefs: [item.targetStateRef!],
+    economicContextRefs: [],
+  };
+
+  const gateway: ProgramExecutionGateway = {
+    async resolveR1ToR5() {
+      calls.push("resolve");
+      return resolution;
+    },
+    async authorize() {
+      calls.push("authorize");
+      return { decisionRef: "warden:sandbox:v49-vetting", outcome: "AUTHORIZED" };
+    },
+    async reserveEvidence() {
+      calls.push("reserve");
+      return { reservationRef: "river-reservation:sandbox:v49-vetting", status: "RESERVED" };
+    },
+    async executeCapability() {
+      calls.push("execute");
+      return { receiptRef: "connector-receipt:sandbox:v49-vetting" };
+    },
+    async confirmResult() {
+      calls.push("confirm");
+      return { confirmationRef: "confirmation:sandbox:v49-vetting", matched: true };
+    },
+    async sealEvidence() {
+      calls.push("seal");
+      return { evidenceRef: "river-evidence:sandbox:v49-vetting" };
+    },
+    async recordEffect() {
+      calls.push("effect");
+      return { effectRef: "effect:sandbox:v49-vetting" };
+    },
+    async recordEconomicConsequence() {
+      calls.push("economic");
+      return null;
+    },
+  };
+
+  return { gateway, calls };
+}
+
+describe("P4 release train / temporal engine adapter", () => {
+  it("preserves the raw schedule milestone and derives -18 weeks from the release anchor", () => {
+    const item = v49VettingSource();
+
+    expect(item.source.locator.cellAddress).toBe("C269");
+    expect(item.source.rawValue).toBe("v49 Start Vetting");
+    expect(item.source.sourceAuthorityStatus).toBe("WORKING_CONTEXT");
+    expect(item.program.programRef).toBe("program:release-train:cldr:v49");
+    expect(item.relativeTemporal?.anchorDate).toBe("2026-10-21");
+    expect(item.relativeTemporal?.sourceDate).toBe("2026-06-17");
+    expect(item.relativeTemporal?.generatedDate).toBe("2026-06-17");
+    expect(item.relativeTemporal?.offsetDaysFromAnchor).toBe(-126);
+    expect(item.relativeTemporal?.offsetWeeksFromAnchor).toBe(-18);
+    expect(item.relativeTemporal?.durationWeeks).toBe(2.75);
+    expect(item.relativeTemporal?.sourceRemainingWeeks).toBe(20);
+    expect(unresolvedGovernanceFields(item)).toHaveLength(7);
+    expect(item.event.authorityRefs).toEqual([]);
+  });
+
+  it("generates the same milestone from a moved release anchor using the relative rule", () => {
+    expect(generateDateFromReleaseAnchor("2026-10-21", -18)).toBe("2026-06-17");
+    expect(generateDateFromReleaseAnchor("2026-10-28", -18)).toBe("2026-06-24");
+  });
+
+  it("keeps the source Remaining value separate from recomputed anchor-relative timing", () => {
+    const item = v49VettingSource();
+
+    expect(item.relativeTemporal?.sourceRemainingWeeks).toBe(20);
+    expect(item.relativeTemporal?.offsetWeeksFromAnchor).toBe(-18);
+    expect(item.relativeTemporal?.sourceRemainingWeeks).not.toBe(Math.abs(item.relativeTemporal!.offsetWeeksFromAnchor));
+  });
+
+  it("fails if a milestone is bound to the wrong release anchor version", () => {
+    expect(() =>
+      adaptReleaseTrainMilestone({
+        locator: {
+          fileName: "CLDR + ICU detailed schedule.xlsx",
+          fileSha256: VERIFIED_SOURCE_SHA256,
+          sheetName: "coordinated",
+          cellAddress: "C269",
+        },
+        stream: "CLDR",
+        releaseVersion: "v49",
+        sourceDate: "2026-06-17",
+        milestoneText: "v49 Start Vetting",
+        anchor: {
+          locator: {
+            fileName: "CLDR + ICU detailed schedule.xlsx",
+            fileSha256: VERIFIED_SOURCE_SHA256,
+            sheetName: "coordinated",
+            cellAddress: "C246",
+          },
+          releaseVersion: "v48",
+          releaseDate: "2025-10-29",
+          rawValue: "v48 Release",
+        },
+      }),
+    ).toThrow("RELEASE_VERSION_ANCHOR_MISMATCH");
+  });
+
+  it("adds governance without promoting the schedule into authority", () => {
+    const source = v49VettingSource();
+    const governed = governedV49Vetting();
+
+    expect(governed.source).toEqual(source.source);
+    expect(unresolvedGovernanceFields(governed)).toEqual([]);
+    expect(governed.event.actingCapacityRef).toBe("role:sandbox:release-manager");
+    expect(governed.event.authorityRefs).toEqual(["authority:sandbox:release-gate"]);
+    expect(governed.event.dependencyRefs).toEqual(["program-dependency:sandbox:submission-complete"]);
+    expect(governed.source.rawValue).not.toBe(governed.event.authorityRefs[0]);
+  });
+
+  it("runs the governed release gate through Program/Event without creating economics", async () => {
+    const item = governedV49Vetting();
+    const { gateway, calls } = gatewayFor(item);
+
+    const result = await runProgramEvent(
+      {
+        program: item.program,
+        event: item.event,
+        correlationId: "corr:sandbox:v49-vetting",
+        idempotencyKey: "idem:sandbox:v49-vetting",
+      },
+      gateway,
+    );
+
+    expect(result.state).toBe("EFFECT_RECORDED");
+    expect(result.evidenceRef).toBe("river-evidence:sandbox:v49-vetting");
+    expect(result.effectRef).toBe("effect:sandbox:v49-vetting");
+    expect(result.economicConsequenceRef).toBeUndefined();
+    expect(calls).toEqual(["resolve", "authorize", "reserve", "execute", "confirm", "seal", "effect", "economic"]);
+  });
+});

--- a/api/adapters/release-train-adapter.ts
+++ b/api/adapters/release-train-adapter.ts
@@ -1,0 +1,247 @@
+import {
+  PROGRAM_EVENT_CONTRACT_VERSION,
+  type EventContractV1,
+  type ProgramContractV1,
+} from "../runtime/program-event-contract.js";
+import {
+  SOURCE_ADAPTER_CONTRACT_VERSION,
+  assertSourceDoesNotGrantAuthority,
+  unresolvedGovernanceFields,
+  type GovernanceFieldResolution,
+  type NormalizedSourceProgramEvent,
+  type SourceLocator,
+} from "./source-adapter-contract.js";
+
+export const RELEASE_TRAIN_ADAPTER_VERSION = "release-train-temporal.v1" as const;
+
+export type ReleaseStream = "CLDR" | "ICU" | "ICU4X" | "UTC_OTHER";
+
+export interface ReleaseAnchorEvidence {
+  locator: SourceLocator;
+  releaseVersion: string;
+  releaseDate: string;
+  rawValue: string;
+}
+
+export interface ReleaseMilestoneInput {
+  locator: SourceLocator;
+  stream: ReleaseStream;
+  releaseVersion: string;
+  sourceDate: string;
+  milestoneText: string;
+  durationWeeks?: number;
+  sourceRemainingWeeks?: number;
+  anchor: ReleaseAnchorEvidence;
+  collisionConstraintRefs?: string[];
+}
+
+export interface ReleaseTrainGovernanceOverlay {
+  ownerRoleRef: string;
+  authorityRefs: string[];
+  evidenceRequirementRefs: string[];
+  dependencyRefs?: string[];
+  constraintRefs?: string[];
+  targetStateRef: string;
+  closureConditionRef: string;
+  r5CandidateRoute: string;
+}
+
+function slug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 100);
+}
+
+function asUtcDate(value: string): Date {
+  const date = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(date.valueOf())) throw new Error(`INVALID_DATE:${value}`);
+  return date;
+}
+
+function isoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export function offsetDaysFromAnchor(sourceDate: string, anchorDate: string): number {
+  const source = asUtcDate(sourceDate);
+  const anchor = asUtcDate(anchorDate);
+  return (source.valueOf() - anchor.valueOf()) / 86_400_000;
+}
+
+export function generateDateFromReleaseAnchor(anchorDate: string, offsetWeeks: number): string {
+  if (!Number.isFinite(offsetWeeks)) throw new Error("INVALID_OFFSET_WEEKS");
+  const anchor = asUtcDate(anchorDate);
+  anchor.setUTCDate(anchor.getUTCDate() + offsetWeeks * 7);
+  return isoDate(anchor);
+}
+
+function governanceSkeleton(): GovernanceFieldResolution[] {
+  return [
+    { field: "owner_role_ref", state: "UNRESOLVED", refs: [], note: "Schedule stream is not a Registry role assignment." },
+    { field: "authority_refs", state: "UNRESOLVED", refs: [], note: "A milestone date does not authorize a release gate." },
+    { field: "dependency_refs", state: "UNRESOLVED", refs: [], note: "Cross-program dependencies require explicit Registry references." },
+    { field: "evidence_requirement_refs", state: "UNRESOLVED", refs: [], note: "Gate evidence is not established by schedule placement." },
+    { field: "target_state_ref", state: "UNRESOLVED", refs: [], note: "Target release state requires governed definition." },
+    { field: "closure_condition_ref", state: "UNRESOLVED", refs: [], note: "Passing time does not close a release gate." },
+    { field: "r5_candidate_route", state: "UNRESOLVED", refs: [], note: "R5 is a candidate route and never authorization." },
+  ];
+}
+
+export function adaptReleaseTrainMilestone(input: ReleaseMilestoneInput): NormalizedSourceProgramEvent {
+  const milestoneText = input.milestoneText.trim();
+  if (!milestoneText) throw new Error("EMPTY_RELEASE_MILESTONE");
+  if (input.releaseVersion !== input.anchor.releaseVersion) throw new Error("RELEASE_VERSION_ANCHOR_MISMATCH");
+
+  const offsetDays = offsetDaysFromAnchor(input.sourceDate, input.anchor.releaseDate);
+  const offsetWeeks = offsetDays / 7;
+  const generatedDate = generateDateFromReleaseAnchor(input.anchor.releaseDate, offsetWeeks);
+  const streamSlug = slug(input.stream);
+  const releaseSlug = slug(input.releaseVersion);
+  const milestoneSlug = slug(milestoneText.replace(new RegExp(`^${input.releaseVersion}\\s*`, "i"), ""));
+  const programRef = `program:release-train:${streamSlug}:${releaseSlug}`;
+  const anchorRef = `temporal-anchor:${streamSlug}:${releaseSlug}:${input.anchor.releaseDate}`;
+  const eventDefinitionRef = `event-def:release-train:${streamSlug}:${releaseSlug}:${input.locator.sourceRow ?? slug(input.locator.cellAddress)}:${milestoneSlug}`;
+
+  const sourceConstraintRefs = [...new Set(input.collisionConstraintRefs ?? [])];
+  const program: ProgramContractV1 = {
+    contractVersion: PROGRAM_EVENT_CONTRACT_VERSION,
+    programRef,
+    programType: "RELEASE_TRAIN",
+    version: 1,
+    sourceRef: `source:${input.locator.fileSha256}`,
+    ownerContextRef: "registry-context:UNRESOLVED",
+    missionPurpose: "Generate governed release milestones from an anchor and relative temporal rules",
+    targetOutcomeRefs: [],
+    contextRefs: [
+      `release-version:${releaseSlug}`,
+      `release-stream:${streamSlug}`,
+      anchorRef,
+      `source-anchor-cell:${input.anchor.locator.sheetName}:${input.anchor.locator.cellAddress}`,
+    ],
+    participantRoleRefs: [],
+    dependencyRefs: [],
+    constraintRefs: sourceConstraintRefs,
+    authorityRefs: [],
+    requirementRefs: [
+      "requirement:release-owner-resolution",
+      "requirement:release-authority-resolution",
+      "requirement:release-gate-evidence",
+      "requirement:release-closure-definition",
+    ],
+    economicRuleRefs: [],
+    settlementContextRefs: [],
+    state: "DRAFT",
+  };
+
+  const event: EventContractV1 = {
+    eventDefinitionRef,
+    programRef,
+    sequence: input.locator.sourceRow ?? 1,
+    actorRef: "digitalme:UNRESOLVED",
+    thingRef: `release-gate:${eventDefinitionRef}`,
+    requestedCapability: "PASS_RELEASE_GATE",
+    dependencyRefs: [],
+    constraintRefs: sourceConstraintRefs,
+    authorityRefs: [],
+    requirementRefs: [...program.requirementRefs],
+    economicRuleRefs: [],
+  };
+
+  const normalized: NormalizedSourceProgramEvent = {
+    contractVersion: SOURCE_ADAPTER_CONTRACT_VERSION,
+    adapterType: "RELEASE_TRAIN",
+    source: {
+      locator: input.locator,
+      rawValue: milestoneText,
+      sourceAuthorityStatus: "WORKING_CONTEXT",
+    },
+    program,
+    event,
+    workstreamRef: `release-stream:${streamSlug}`,
+    relativeTemporal: {
+      anchorRef,
+      anchorDate: input.anchor.releaseDate,
+      sourceDate: input.sourceDate,
+      generatedDate,
+      offsetDaysFromAnchor: offsetDays,
+      offsetWeeksFromAnchor: offsetWeeks,
+      durationWeeks: input.durationWeeks,
+      sourceRemainingWeeks: input.sourceRemainingWeeks,
+      collisionConstraintRefs: sourceConstraintRefs,
+    },
+    governance: governanceSkeleton(),
+    lifecycleState: "READY_FOR_GOVERNANCE",
+  };
+
+  assertSourceDoesNotGrantAuthority(normalized);
+  return normalized;
+}
+
+function resolved(field: GovernanceFieldResolution["field"], refs: string[], note?: string): GovernanceFieldResolution {
+  return { field, state: "RESOLVED", refs, note };
+}
+
+export function applyReleaseTrainGovernanceOverlay(
+  sourceItem: NormalizedSourceProgramEvent,
+  overlay: ReleaseTrainGovernanceOverlay,
+): NormalizedSourceProgramEvent {
+  if (sourceItem.adapterType !== "RELEASE_TRAIN") throw new Error("WRONG_ADAPTER_TYPE");
+  if (!overlay.ownerRoleRef) throw new Error("OWNER_ROLE_REQUIRED");
+  if (!overlay.authorityRefs.length) throw new Error("AUTHORITY_REQUIRED");
+  if (!overlay.evidenceRequirementRefs.length) throw new Error("EVIDENCE_REQUIREMENT_REQUIRED");
+  if (!overlay.targetStateRef) throw new Error("TARGET_STATE_REQUIRED");
+  if (!overlay.closureConditionRef) throw new Error("CLOSURE_CONDITION_REQUIRED");
+  if (!overlay.r5CandidateRoute) throw new Error("R5_ROUTE_REQUIRED");
+
+  const dependencyRefs = [...new Set(overlay.dependencyRefs ?? [])];
+  const constraintRefs = [
+    ...new Set([...(sourceItem.event.constraintRefs ?? []), ...(overlay.constraintRefs ?? [])]),
+  ];
+  const authorityRefs = [...new Set(overlay.authorityRefs)];
+  const requirementRefs = [...new Set(overlay.evidenceRequirementRefs)];
+
+  const governed: NormalizedSourceProgramEvent = {
+    ...sourceItem,
+    program: {
+      ...sourceItem.program,
+      ownerContextRef: overlay.ownerRoleRef,
+      participantRoleRefs: [overlay.ownerRoleRef],
+      authorityRefs,
+      requirementRefs,
+      dependencyRefs,
+      constraintRefs,
+      targetOutcomeRefs: [overlay.targetStateRef],
+      state: "READY_FOR_AUTHORIZATION",
+    },
+    event: {
+      ...sourceItem.event,
+      actorRef: `digitalme-for:${overlay.ownerRoleRef}`,
+      actingCapacityRef: overlay.ownerRoleRef,
+      authorityRefs,
+      requirementRefs,
+      dependencyRefs,
+      constraintRefs,
+    },
+    ownerRoleRef: overlay.ownerRoleRef,
+    targetStateRef: overlay.targetStateRef,
+    closureConditionRef: overlay.closureConditionRef,
+    r5CandidateRoute: overlay.r5CandidateRoute,
+    governance: [
+      resolved("owner_role_ref", [overlay.ownerRoleRef]),
+      resolved("authority_refs", authorityRefs),
+      resolved("dependency_refs", dependencyRefs, dependencyRefs.length ? undefined : "No cross-program dependency supplied for this sandbox gate."),
+      resolved("evidence_requirement_refs", requirementRefs),
+      resolved("target_state_ref", [overlay.targetStateRef]),
+      resolved("closure_condition_ref", [overlay.closureConditionRef]),
+      resolved("r5_candidate_route", [overlay.r5CandidateRoute]),
+    ],
+    lifecycleState: "READY_FOR_RUNTIME",
+  };
+
+  if (unresolvedGovernanceFields(governed).length) throw new Error("GOVERNANCE_OVERLAY_INCOMPLETE");
+  assertSourceDoesNotGrantAuthority(governed);
+  return governed;
+}

--- a/api/adapters/source-adapter-contract.ts
+++ b/api/adapters/source-adapter-contract.ts
@@ -43,6 +43,18 @@ export interface TemporalProjection {
   dueWindowRef?: string;
 }
 
+export interface RelativeTemporalProjection {
+  anchorRef: string;
+  anchorDate: string;
+  sourceDate: string;
+  generatedDate: string;
+  offsetDaysFromAnchor: number;
+  offsetWeeksFromAnchor: number;
+  durationWeeks?: number;
+  sourceRemainingWeeks?: number;
+  collisionConstraintRefs: string[];
+}
+
 export interface NormalizedSourceProgramEvent {
   contractVersion: typeof SOURCE_ADAPTER_CONTRACT_VERSION;
   adapterType: "ANNUAL_OPERATING_CALENDAR" | "RELEASE_TRAIN" | "CREATOR_PROGRAMME" | "ECONOMIC_MODEL";
@@ -52,6 +64,7 @@ export interface NormalizedSourceProgramEvent {
   workstreamRef?: string;
   ownerRoleRef?: string;
   temporal?: TemporalProjection;
+  relativeTemporal?: RelativeTemporalProjection;
   governance: GovernanceFieldResolution[];
   targetStateRef?: string;
   closureConditionRef?: string;


### PR DESCRIPTION
Implements Adapter B of `Believers-common-group/SynergyzeGovernance#14` as a stacked PR over #29.

Source: `CLDR + ICU detailed schedule.xlsx`, SHA-256 `1bb907613dfbd185cf208df636c900f4f824420e0a3dc735084a67cdb61f6674`.

Verified v49 source slice from `coordinated`:
- milestone: `C269` = `v49 Start Vetting`
- source date: 2026-06-17
- duration: 2.75 weeks
- source Remaining: 20
- release anchor: `C281` = `v49 Release`
- release date: 2026-10-21

The adapter derives the actual anchor-relative rule from the source date/anchor pair: -126 days / -18 weeks. It preserves the source Remaining value separately rather than treating it as canonical when the two differ.

Adds:
- relative temporal projection fields to the common source adapter envelope;
- release milestone adapter with anchor-relative date generation;
- release-version/anchor consistency checks;
- separate governance overlay for owner/authority/evidence/dependencies/closure/R5;
- tests proving anchor movement regenerates dates, source helper values remain distinct from derived timing, wrong-version anchors fail closed, and one governed release gate executes through Program/Event to River evidence + Effect without economics;
- path-scoped CI.

Boundary: schedule data remains `WORKING_CONTEXT`; a date or milestone does not authorize a release gate. Holiday/UTC collision handling remains an explicit constraint/exception input.

Stack dependency: #29, then #28.
Related governance: `SynergyzeGovernance#14`, parent `#10`.