### PR TITLE
P4: adapt creator property participation programme

### DIFF
--- a/.github/workflows/p4-creator-programme-adapter-test.yml
+++ b/.github/workflows/p4-creator-programme-adapter-test.yml
@@ -1,0 +1,30 @@
+name: p4-creator-programme-adapter-test
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    paths:
+      - 'api/adapters/**'
+      - 'api/runtime/**'
+      - '.github/workflows/p4-creator-programme-adapter-test.yml'
+
+jobs:
+  creator-programme-adapter:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Run focused creator programme adapter tests
+        run: npx vitest run api/adapters/creator-programme-adapter.test.ts
+
+      - name: Type-check API runtime and adapters
+        run: npm run -s type-check

--- a/api/adapters/creator-programme-adapter.test.ts
+++ b/api/adapters/creator-programme-adapter.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+
+import { runProgramEvent } from "../runtime/program-runner.js";
+import type { ProgramExecutionGateway, RegistryResolutionBundle } from "../runtime/program-event-contract.js";
+import { unresolvedGovernanceFields } from "./source-adapter-contract.js";
+import {
+  CREATOR_PROGRAMME_REF,
+  adaptCreatorProgrammeEvent,
+  applyCreatorProgrammeSandboxOverlay,
+} from "./creator-programme-adapter.js";
+
+const MASTER_SHA256 = "ae717423f1a2521c315cecaaf41685333474a8c8cbdedd75d1091f112598d400";
+const IDEA_BANK_SHA256 = "25ae24a9fda43c29cc1a3b7c8a9b97c808847c0c1d6acbf372ebe27b1d92e7ff";
+
+function eventOneSource() {
+  return adaptCreatorProgrammeEvent({
+    locator: {
+      fileName: "VSR_Earthen_Empire_Creators_Programme_Master(1).xlsx",
+      fileSha256: MASTER_SHA256,
+      sheetName: "33 Event Programme",
+      cellAddress: "A5:U5",
+      sourceRow: 5,
+      sourceSerial: 1,
+    },
+    sourceCalendar: {
+      locator: {
+        fileName: "tiktok_real_estate_content_calendar_33_days 2.xlsx",
+        fileSha256: IDEA_BANK_SHA256,
+        sheetName: "Content Calendar",
+        cellAddress: "A2:F2",
+        sourceRow: 2,
+        sourceSerial: 1,
+      },
+      day: 1,
+      contentTheme: "Listing of the Week",
+      hook: "This house costs a fortune, and I still can’t believe this feature made the final cut.",
+      caption: "$2M and this is the feature they’re leading with? #realestate #housetour #propertyreview",
+      cta: "Would you pay for this?",
+      status: "Idea",
+    },
+    eventId: "VSR-CC-PROP-EVT-001",
+    day: 1,
+    programmeAct: "ACT I - SEE THE PLACE",
+    contentPillar: "PLACE & DESIGN",
+    programmeRail: "MEDIA & PARTICIPATION RAIL",
+    contentTheme: "Listing of the Week",
+    openingHook: "This house costs a fortune, and I still can’t believe this feature made the final cut.",
+    registryResolution: "R3 WHAT APPLIES - claim, licence and price context",
+    sourceAssetId: "SRC-CAL-001-D01",
+    evidenceRequirementText: "Registered place ID; permitted photos/video/plan; observation timestamp; material/condition source; factual boundary",
+    rightsAuthorityGateText: "Contributor authority + source-media rights + property-claim scope + CCL acceptance + Warden authorization",
+    creatorBrief: "Choose one registered property and explain one decisive feature. Separate observation, sourced fact and opinion.",
+    ctaRequestRoute: "EXPLORE - open registered Property / Quantum Room",
+    expectedEffectText: "Registered property or Quantum Room view opened",
+    cclProfileRef: "CCL-PROP-STORY-001",
+    wardenDecision: "PENDING",
+    programmeState: "PLANNED",
+  });
+}
+
+function governedEventOne() {
+  return applyCreatorProgrammeSandboxOverlay(eventOneSource(), {
+    creatorDigitalMeRef: "digitalme:sandbox:creator-001",
+    actingCapacityRef: "role:sandbox:creator",
+    placeRef: "place:sandbox:property-001",
+    authorityRefs: ["authority:sandbox:creator-source-rights", "authority:sandbox:property-claim-scope"],
+    evidenceRequirementRefs: [
+      "requirement:sandbox:registered-place",
+      "requirement:sandbox:permitted-source-media",
+      "requirement:sandbox:factual-boundary-evidence",
+    ],
+    cclAcceptanceRef: "ccl-acceptance:sandbox:creator-001:event-001",
+    ccreEnvelopeRef: "ccre:sandbox:creator-001:event-001",
+    targetStateRef: "state:sandbox:property-room-view-opened",
+    closureConditionRef: "closure:sandbox:verified-view-open-effect",
+    r5CandidateRoute: "route:sandbox:open-property-quantum-room",
+  });
+}
+
+function gatewayFor(item: ReturnType<typeof governedEventOne>) {
+  const calls: string[] = [];
+  const resolution: RegistryResolutionBundle = {
+    requestRef: "registry-request:sandbox:creator-event-001",
+    r1: "RESOLVED",
+    r2: "RESOLVED",
+    r3: "REQUIRES_AUTHORIZATION",
+    r4: "RESOLVED",
+    r5: "RESOLVED",
+    candidateAction: item.r5CandidateRoute,
+    unmetRequirementRefs: [],
+    authorityRefs: item.event.authorityRefs,
+    evidenceRequirementRefs: item.event.requirementRefs,
+    expectedEffectRefs: [item.targetStateRef!],
+    economicContextRefs: [],
+  };
+
+  const gateway: ProgramExecutionGateway = {
+    async resolveR1ToR5() {
+      calls.push("resolve");
+      return resolution;
+    },
+    async authorize() {
+      calls.push("authorize");
+      return { decisionRef: "warden:sandbox:creator-event-001", outcome: "AUTHORIZED" };
+    },
+    async reserveEvidence() {
+      calls.push("reserve");
+      return { reservationRef: "river-reservation:sandbox:creator-event-001", status: "RESERVED" };
+    },
+    async executeCapability() {
+      calls.push("execute");
+      return { receiptRef: "connector-receipt:sandbox:creator-event-001" };
+    },
+    async confirmResult() {
+      calls.push("confirm");
+      return { confirmationRef: "confirmation:sandbox:creator-event-001", matched: true };
+    },
+    async sealEvidence() {
+      calls.push("seal");
+      return { evidenceRef: "river-evidence:sandbox:creator-event-001" };
+    },
+    async recordEffect() {
+      calls.push("effect");
+      return { effectRef: "effect:sandbox:creator-event-001" };
+    },
+    async recordEconomicConsequence() {
+      calls.push("economic");
+      return null;
+    },
+  };
+
+  return { gateway, calls };
+}
+
+describe("P4 creator/property participation adapter", () => {
+  it("preserves the primary master Event and the original 33-day source row separately", () => {
+    const item = eventOneSource();
+
+    expect(item.programmeRef).toBe(CREATOR_PROGRAMME_REF);
+    expect(item.program.programRef).toBe(CREATOR_PROGRAMME_REF);
+    expect(item.program.state).toBe("DRAFT");
+    expect(item.event.eventDefinitionRef).toBe("VSR-CC-PROP-EVT-001");
+    expect(item.source.locator.fileSha256).toBe(MASTER_SHA256);
+    expect(item.source.locator.cellAddress).toBe("A5:U5");
+    expect(item.sourceCalendar.locator.fileSha256).toBe(IDEA_BANK_SHA256);
+    expect(item.sourceCalendar.locator.cellAddress).toBe("A2:F2");
+    expect(item.source.sourceAuthorityStatus).toBe("WORKING_CONTEXT");
+    expect(item.licenceEffectState).toBe("NOT_EFFECTIVE");
+    expect(item.economicsState).toBe("NEEDS_POLICY");
+    expect(unresolvedGovernanceFields(item)).toHaveLength(7);
+  });
+
+  it("keeps CTA content distinct from the governed R5 request route", () => {
+    const item = eventOneSource();
+
+    expect(item.ctaText).toBe("Would you pay for this?");
+    expect(item.ctaRouteText).toBe("EXPLORE - open registered Property / Quantum Room");
+    expect(item.r5CandidateRoute).toBe(item.ctaRouteText);
+    expect(item.ctaText).not.toBe(item.r5CandidateRoute);
+    expect(item.event.authorityRefs).toEqual([]);
+    expect(item.program.economicRuleRefs).toEqual([]);
+  });
+
+  it("preserves the CCRE default denials for training, fine-tuning and distillation", () => {
+    const item = eventOneSource();
+
+    expect(item.computationPermissions.VIEW).toBe("ALLOW");
+    expect(item.computationPermissions.RAG).toBe("CONDITIONAL");
+    expect(item.computationPermissions.TRAIN).toBe("DENY");
+    expect(item.computationPermissions.FINE_TUNE).toBe("DENY");
+    expect(item.computationPermissions.DISTILL).toBe("DENY");
+  });
+
+  it("refuses a non-sandbox overlay so testing cannot imply real creator rights", () => {
+    expect(() =>
+      applyCreatorProgrammeSandboxOverlay(eventOneSource(), {
+        creatorDigitalMeRef: "digitalme:creator-real",
+        actingCapacityRef: "role:creator",
+        placeRef: "place:property-real",
+        authorityRefs: ["authority:creator-real"],
+        evidenceRequirementRefs: ["requirement:evidence"],
+        cclAcceptanceRef: "ccl-acceptance:real",
+        ccreEnvelopeRef: "ccre:real",
+        targetStateRef: "state:view-opened",
+        closureConditionRef: "closure:verified",
+        r5CandidateRoute: "route:open-property",
+      }),
+    ).toThrow("SANDBOX_DIGITALME_REQUIRED");
+  });
+
+  it("adds only synthetic rights/evidence refs without changing source evidence or TRAIN denial", () => {
+    const source = eventOneSource();
+    const governed = governedEventOne();
+
+    expect(governed.source).toEqual(source.source);
+    expect(governed.sourceCalendar).toEqual(source.sourceCalendar);
+    expect(governed.licenceEffectState).toBe("EFFECTIVE_SANDBOX");
+    expect(unresolvedGovernanceFields(governed)).toEqual([]);
+    expect(governed.event.actorRef).toBe("digitalme:sandbox:creator-001");
+    expect(governed.event.placeRef).toBe("place:sandbox:property-001");
+    expect(governed.event.authorityRefs.every((ref) => ref.startsWith("authority:sandbox:"))).toBe(true);
+    expect(governed.computationPermissions.TRAIN).toBe("DENY");
+    expect(governed.economicsState).toBe("NEEDS_POLICY");
+  });
+
+  it("runs the sandbox participation request through Program/Event to evidence + Effect but no economics", async () => {
+    const item = governedEventOne();
+    const { gateway, calls } = gatewayFor(item);
+
+    const result = await runProgramEvent(
+      {
+        program: item.program,
+        event: item.event,
+        correlationId: "corr:sandbox:creator-event-001",
+        idempotencyKey: "idem:sandbox:creator-event-001",
+      },
+      gateway,
+    );
+
+    expect(result.state).toBe("EFFECT_RECORDED");
+    expect(result.evidenceRef).toBe("river-evidence:sandbox:creator-event-001");
+    expect(result.effectRef).toBe("effect:sandbox:creator-event-001");
+    expect(result.economicConsequenceRef).toBeUndefined();
+    expect(item.economicsState).toBe("NEEDS_POLICY");
+    expect(calls).toEqual(["resolve", "authorize", "reserve", "execute", "confirm", "seal", "effect", "economic"]);
+  });
+});

--- a/api/adapters/creator-programme-adapter.ts
+++ b/api/adapters/creator-programme-adapter.ts
@@ -1,0 +1,276 @@
+import {
+  PROGRAM_EVENT_CONTRACT_VERSION,
+  type EventContractV1,
+  type ProgramContractV1,
+} from "../runtime/program-event-contract.js";
+import {
+  SOURCE_ADAPTER_CONTRACT_VERSION,
+  assertSourceDoesNotGrantAuthority,
+  unresolvedGovernanceFields,
+  type GovernanceFieldResolution,
+  type NormalizedSourceProgramEvent,
+  type SourceLocator,
+} from "./source-adapter-contract.js";
+
+export const CREATOR_PROGRAMME_ADAPTER_VERSION = "creator-property-participation.v1" as const;
+export const CREATOR_PROGRAMME_REF = "VSR-CC-PROP-PROG-001" as const;
+
+export type LicenceEffectState = "NOT_EFFECTIVE" | "EFFECTIVE_SANDBOX";
+export type ComputationPermission = "ALLOW" | "CONDITIONAL" | "DENY";
+
+export interface CreatorSourceCalendarEvidence {
+  locator: SourceLocator;
+  day: number;
+  contentTheme: string;
+  hook: string;
+  caption: string;
+  cta: string;
+  status: string;
+}
+
+export interface CreatorMasterEventInput {
+  locator: SourceLocator;
+  sourceCalendar: CreatorSourceCalendarEvidence;
+  eventId: string;
+  day: number;
+  programmeAct: string;
+  contentPillar: string;
+  programmeRail: string;
+  contentTheme: string;
+  openingHook: string;
+  registryResolution: string;
+  sourceAssetId: string;
+  evidenceRequirementText: string;
+  rightsAuthorityGateText: string;
+  creatorBrief: string;
+  ctaRequestRoute: string;
+  expectedEffectText: string;
+  cclProfileRef: string;
+  wardenDecision: string;
+  programmeState: string;
+}
+
+export interface CreatorProgrammeGovernanceOverlay {
+  creatorDigitalMeRef: string;
+  actingCapacityRef: string;
+  placeRef: string;
+  authorityRefs: string[];
+  evidenceRequirementRefs: string[];
+  cclAcceptanceRef: string;
+  ccreEnvelopeRef: string;
+  targetStateRef: string;
+  closureConditionRef: string;
+  r5CandidateRoute: string;
+}
+
+export interface CreatorProgrammeNormalizedEvent extends NormalizedSourceProgramEvent {
+  programmeRef: typeof CREATOR_PROGRAMME_REF;
+  sourceCalendar: CreatorSourceCalendarEvidence;
+  sourceAssetId: string;
+  cclProfileRef: string;
+  ccreEnvelopeRef?: string;
+  licenceEffectState: LicenceEffectState;
+  ctaText: string;
+  ctaRouteText: string;
+  expectedEffectText: string;
+  rightsAuthorityGateText: string;
+  economicsState: "NEEDS_POLICY";
+  computationPermissions: {
+    VIEW: ComputationPermission;
+    INDEX: ComputationPermission;
+    EMBED: ComputationPermission;
+    RAG: ComputationPermission;
+    TRAIN: ComputationPermission;
+    FINE_TUNE: ComputationPermission;
+    DISTILL: ComputationPermission;
+  };
+}
+
+function governanceSkeleton(): GovernanceFieldResolution[] {
+  return [
+    { field: "owner_role_ref", state: "UNRESOLVED", refs: [], note: "Creator role/capacity must resolve through Registry/DigitalMe." },
+    { field: "authority_refs", state: "UNRESOLVED", refs: [], note: "Submission, upload, selection, signature and payment do not establish controlled rights." },
+    { field: "dependency_refs", state: "UNRESOLVED", refs: [], note: "Place/source/CCRE/CCL dependencies require explicit governed references." },
+    { field: "evidence_requirement_refs", state: "UNRESOLVED", refs: [], note: "Master text describes evidence classes but does not prove evidence satisfaction." },
+    { field: "target_state_ref", state: "UNRESOLVED", refs: [], note: "Expected effect text is a programme expectation, not a verified Effect." },
+    { field: "closure_condition_ref", state: "UNRESOLVED", refs: [], note: "Publication, reach or payment alone cannot close the Event." },
+    { field: "r5_candidate_route", state: "UNRESOLVED", refs: [], note: "CTA/request route is a candidate next action, not authority or entitlement." },
+  ];
+}
+
+export function adaptCreatorProgrammeEvent(input: CreatorMasterEventInput): CreatorProgrammeNormalizedEvent {
+  if (input.day <= 0 || input.sourceCalendar.day !== input.day) throw new Error("CREATOR_DAY_MISMATCH");
+  if (input.sourceCalendar.contentTheme.trim() !== input.contentTheme.trim()) throw new Error("CREATOR_THEME_SOURCE_MISMATCH");
+  if (!input.eventId.startsWith("VSR-CC-PROP-EVT-")) throw new Error("INVALID_CREATOR_EVENT_ID");
+  if (input.wardenDecision.trim().toUpperCase() !== "PENDING") throw new Error("SOURCE_WARDEN_STATE_MUST_REMAIN_PENDING");
+
+  const program: ProgramContractV1 = {
+    contractVersion: PROGRAM_EVENT_CONTRACT_VERSION,
+    programRef: CREATOR_PROGRAMME_REF,
+    programType: "CREATOR_PROPERTY_PARTICIPATION",
+    version: 1,
+    sourceRef: `source:${input.locator.fileSha256}`,
+    ownerContextRef: "registry-context:ALPHA-NODE-001",
+    missionPurpose: "Turn registered Places/property evidence into licensed creator contributions and governed participation requests without collapsing ownership, authority, truth, output or economics",
+    targetOutcomeRefs: [],
+    contextRefs: [
+      "registry-home:ALPHA-NODE-001",
+      "gate:VSR:FRONT",
+      "gate:EMPIRE:BACK",
+      `programme-act:${input.programmeAct}`,
+      `programme-rail:${input.programmeRail}`,
+      `content-pillar:${input.contentPillar}`,
+      `ccl-profile:${input.cclProfileRef}`,
+    ],
+    participantRoleRefs: [],
+    dependencyRefs: [
+      `source-asset:${input.sourceAssetId}`,
+      "dependency:registered-place",
+      "dependency:ccre-envelope",
+      "dependency:ccl-acceptance",
+      "dependency:warden-authorization",
+    ],
+    constraintRefs: [
+      "constraint:source-ne-model-ne-output",
+      "constraint:registration-ne-ownership",
+      "constraint:signature-ne-authority",
+      "constraint:payment-ne-rights-transfer",
+      "constraint:reach-ne-effect",
+      "constraint:economics-needs-policy",
+    ],
+    authorityRefs: [],
+    requirementRefs: [
+      "requirement:creator-authority-verification",
+      "requirement:source-media-rights",
+      "requirement:property-claim-scope",
+      "requirement:ccl-acceptance",
+      "requirement:warden-authorization",
+      "requirement:creator-event-evidence",
+    ],
+    economicRuleRefs: [],
+    settlementContextRefs: [],
+    state: "DRAFT",
+  };
+
+  const event: EventContractV1 = {
+    eventDefinitionRef: input.eventId,
+    programRef: CREATOR_PROGRAMME_REF,
+    sequence: input.day,
+    actorRef: "digitalme:UNRESOLVED",
+    thingRef: `source-asset:${input.sourceAssetId}`,
+    requestedCapability: "CREATE_LICENSED_PROPERTY_STORY",
+    dependencyRefs: [...program.dependencyRefs],
+    constraintRefs: [...program.constraintRefs],
+    authorityRefs: [],
+    requirementRefs: [...program.requirementRefs],
+    economicRuleRefs: [],
+  };
+
+  const item: CreatorProgrammeNormalizedEvent = {
+    contractVersion: SOURCE_ADAPTER_CONTRACT_VERSION,
+    adapterType: "CREATOR_PROGRAMME",
+    source: {
+      locator: input.locator,
+      rawValue: input.contentTheme.trim(),
+      sourceAuthorityStatus: "WORKING_CONTEXT",
+    },
+    program,
+    event,
+    workstreamRef: `programme-rail:${input.programmeRail}`,
+    governance: governanceSkeleton(),
+    r5CandidateRoute: input.ctaRequestRoute,
+    lifecycleState: "READY_FOR_GOVERNANCE",
+    programmeRef: CREATOR_PROGRAMME_REF,
+    sourceCalendar: input.sourceCalendar,
+    sourceAssetId: input.sourceAssetId,
+    cclProfileRef: input.cclProfileRef,
+    licenceEffectState: "NOT_EFFECTIVE",
+    ctaText: input.sourceCalendar.cta,
+    ctaRouteText: input.ctaRequestRoute,
+    expectedEffectText: input.expectedEffectText,
+    rightsAuthorityGateText: input.rightsAuthorityGateText,
+    economicsState: "NEEDS_POLICY",
+    computationPermissions: {
+      VIEW: "ALLOW",
+      INDEX: "CONDITIONAL",
+      EMBED: "CONDITIONAL",
+      RAG: "CONDITIONAL",
+      TRAIN: "DENY",
+      FINE_TUNE: "DENY",
+      DISTILL: "DENY",
+    },
+  };
+
+  assertSourceDoesNotGrantAuthority(item);
+  return item;
+}
+
+function resolved(field: GovernanceFieldResolution["field"], refs: string[], note?: string): GovernanceFieldResolution {
+  return { field, state: "RESOLVED", refs, note };
+}
+
+export function applyCreatorProgrammeSandboxOverlay(
+  sourceItem: CreatorProgrammeNormalizedEvent,
+  overlay: CreatorProgrammeGovernanceOverlay,
+): CreatorProgrammeNormalizedEvent {
+  if (!overlay.creatorDigitalMeRef.startsWith("digitalme:sandbox:")) throw new Error("SANDBOX_DIGITALME_REQUIRED");
+  if (!overlay.authorityRefs.length || !overlay.authorityRefs.every((ref) => ref.startsWith("authority:sandbox:"))) {
+    throw new Error("SANDBOX_AUTHORITY_REQUIRED");
+  }
+  if (!overlay.cclAcceptanceRef.startsWith("ccl-acceptance:sandbox:")) throw new Error("SANDBOX_CCL_ACCEPTANCE_REQUIRED");
+  if (!overlay.ccreEnvelopeRef.startsWith("ccre:sandbox:")) throw new Error("SANDBOX_CCRE_REQUIRED");
+  if (!overlay.evidenceRequirementRefs.length) throw new Error("EVIDENCE_REQUIREMENT_REQUIRED");
+  if (!overlay.placeRef.startsWith("place:sandbox:")) throw new Error("SANDBOX_PLACE_REQUIRED");
+
+  const dependencyRefs = [
+    `source-asset:${sourceItem.sourceAssetId}`,
+    overlay.placeRef,
+    overlay.cclAcceptanceRef,
+    overlay.ccreEnvelopeRef,
+  ];
+  const authorityRefs = [...new Set(overlay.authorityRefs)];
+  const evidenceRequirementRefs = [...new Set(overlay.evidenceRequirementRefs)];
+
+  const governed: CreatorProgrammeNormalizedEvent = {
+    ...sourceItem,
+    program: {
+      ...sourceItem.program,
+      participantRoleRefs: [overlay.actingCapacityRef],
+      authorityRefs,
+      requirementRefs: evidenceRequirementRefs,
+      dependencyRefs,
+      targetOutcomeRefs: [overlay.targetStateRef],
+      state: "READY_FOR_AUTHORIZATION",
+    },
+    event: {
+      ...sourceItem.event,
+      actorRef: overlay.creatorDigitalMeRef,
+      actingCapacityRef: overlay.actingCapacityRef,
+      placeRef: overlay.placeRef,
+      authorityRefs,
+      requirementRefs: evidenceRequirementRefs,
+      dependencyRefs,
+    },
+    ownerRoleRef: overlay.actingCapacityRef,
+    ccreEnvelopeRef: overlay.ccreEnvelopeRef,
+    licenceEffectState: "EFFECTIVE_SANDBOX",
+    targetStateRef: overlay.targetStateRef,
+    closureConditionRef: overlay.closureConditionRef,
+    r5CandidateRoute: overlay.r5CandidateRoute,
+    governance: [
+      resolved("owner_role_ref", [overlay.actingCapacityRef]),
+      resolved("authority_refs", authorityRefs),
+      resolved("dependency_refs", dependencyRefs),
+      resolved("evidence_requirement_refs", evidenceRequirementRefs),
+      resolved("target_state_ref", [overlay.targetStateRef]),
+      resolved("closure_condition_ref", [overlay.closureConditionRef]),
+      resolved("r5_candidate_route", [overlay.r5CandidateRoute], "CTA resolves only to a governed candidate route."),
+    ],
+    lifecycleState: "READY_FOR_RUNTIME",
+  };
+
+  if (unresolvedGovernanceFields(governed).length) throw new Error("CREATOR_GOVERNANCE_OVERLAY_INCOMPLETE");
+  if (governed.computationPermissions.TRAIN !== "DENY") throw new Error("TRAIN_PERMISSION_ESCALATED");
+  assertSourceDoesNotGrantAuthority(governed);
+  return governed;
+}


### PR DESCRIPTION
Implements Adapter C of `Believers-common-group/SynergyzeGovernance#14` as a stacked PR over #31.

Primary normalized source: `VSR_Earthen_Empire_Creators_Programme_Master(1).xlsx`, SHA-256 `ae717423f1a2521c315cecaaf41685333474a8c8cbdedd75d1091f112598d400`.
Original idea-bank source: `tiktok_real_estate_content_calendar_33_days 2.xlsx`, SHA-256 `25ae24a9fda43c29cc1a3b7c8a9b97c808847c0c1d6acbf372ebe27b1d92e7ff`.

First verified instance:
- programme `VSR-CC-PROP-PROG-001`
- Event `VSR-CC-PROP-EVT-001`
- master row `33 Event Programme!A5:U5`
- source idea row `Content Calendar!A2:F2`
- theme `Listing of the Week`
- source CTA `Would you pay for this?`
- governed request route `EXPLORE - open registered Property / Quantum Room`
- CCL profile `CCL-PROP-STORY-001`

Hard boundaries encoded from the source master:
- programme stays DRAFT until governance is satisfied;
- CCL is NOT EFFECTIVE by default;
- SOURCE != MODEL != OUTPUT;
- upload/access/signature/selection/payment do not imply permission;
- CTA is distinct from the R5 candidate request route;
- TRAIN, FINE_TUNE and DISTILL remain DENY under the recovered CCRE permission matrix;
- economics stays NEEDS_POLICY and cannot be created by reach, publication, selection or payment;
- the executable overlay accepts only explicit `sandbox:*` identities/authority/place/CCRE/CCL refs so tests cannot imply real creator/property rights.

Focused tests prove source/master separation, CTA-vs-route separation, default computation denials, rejection of non-sandbox rights overlays, immutable source evidence, and a sandbox participation request reaching River evidence + Effect through Program/Event with no economic consequence.

Stack dependency: #31 -> #29 -> #28.
Related governance: `SynergyzeGovernance#14`, parent `#10`.