### PR TITLE
BNR-PARTICIPANT-CONFORMANCE-001: make R1-R5 participant success testable

### DIFF
--- a/.github/workflows/bnr-participant-conformance-test.yml
+++ b/.github/workflows/bnr-participant-conformance-test.yml
@@ -1,0 +1,40 @@
+name: bnr-participant-conformance-test
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    paths:
+      - 'api/runtime/participant-conformance.ts'
+      - 'api/runtime/participant-conformance.test.ts'
+      - 'api/runtime/program-event-contract.ts'
+      - 'docs/bnr/BNR-PARTICIPANT-CONFORMANCE-001.md'
+      - '.github/workflows/bnr-participant-conformance-test.yml'
+  push:
+    branches:
+      - genesis
+    paths:
+      - 'api/runtime/participant-conformance.ts'
+      - 'api/runtime/participant-conformance.test.ts'
+      - 'api/runtime/program-event-contract.ts'
+      - '.github/workflows/bnr-participant-conformance-test.yml'
+
+jobs:
+  participant-conformance:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Run focused BNR participant conformance tests
+        run: npx vitest run api/runtime/participant-conformance.test.ts
+
+      - name: Type-check API runtime
+        run: npm run -s type-check

--- a/api/runtime/participant-conformance.test.ts
+++ b/api/runtime/participant-conformance.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  RegistryResolutionBundle,
+  WardenAuthorizationResult,
+} from "./program-event-contract.js";
+import { assessBnrParticipantConformance } from "./participant-conformance.js";
+
+function resolved(): RegistryResolutionBundle {
+  return {
+    requestRef: "registry-request:test:participant",
+    r1: "RESOLVED",
+    r2: "RESOLVED",
+    r3: "REQUIRES_AUTHORIZATION",
+    r4: "RESOLVED",
+    r5: "RESOLVED",
+    candidateAction: "ENTER_QUANTUM_ROOM",
+    unmetRequirementRefs: [],
+    authorityRefs: ["authority:test:participation"],
+    evidenceRequirementRefs: ["evidence:test:identity"],
+    expectedEffectRefs: ["effect:test:entry"],
+    economicContextRefs: [],
+  };
+}
+
+function warden(
+  outcome: WardenAuthorizationResult["outcome"],
+): WardenAuthorizationResult {
+  return {
+    decisionRef: `warden:test:${outcome.toLowerCase()}`,
+    outcome,
+    reason: outcome === "DENIED" ? "scope_not_permitted" : undefined,
+  };
+}
+
+describe("BNR participant conformance v1", () => {
+  it("is conformant and executable only after explicit Warden authorization", () => {
+    const snapshot = assessBnrParticipantConformance(resolved(), warden("AUTHORIZED"));
+
+    expect(snapshot.experienceStatus).toBe("CONFORMANT");
+    expect(snapshot.actionability).toBe("EXECUTABLE");
+    expect(snapshot.recognized.code).toBe("IDENTITY_RECOGNIZED");
+    expect(snapshot.connected.code).toBe("RELATIONSHIP_RESOLVED");
+    expect(snapshot.applies.code).toBe("WARDEN_AUTHORIZATION_REQUIRED");
+    expect(snapshot.required.code).toBe("REQUIREMENTS_SATISFIED");
+    expect(snapshot.next.code).toBe("NEXT_AUTHORIZED");
+    expect(snapshot.nextAction).toMatchObject({
+      state: "EXECUTE_AUTHORIZED_ACTION",
+      executable: true,
+      candidateAction: "ENTER_QUANTUM_ROOM",
+      decisionRef: "warden:test:authorized",
+    });
+    expect(snapshot.unresolvedQuestions).toEqual([]);
+  });
+
+  it("never treats a resolved R5 candidate as executable without Warden", () => {
+    const snapshot = assessBnrParticipantConformance(resolved());
+
+    expect(snapshot.experienceStatus).toBe("CONFORMANT");
+    expect(snapshot.actionability).toBe("KNOWN_BLOCKER");
+    expect(snapshot.next.code).toBe("NEXT_AWAIT_WARDEN_AUTHORIZATION");
+    expect(snapshot.nextAction).toMatchObject({
+      state: "AWAIT_WARDEN_AUTHORIZATION",
+      executable: false,
+      candidateAction: "ENTER_QUANTUM_ROOM",
+    });
+  });
+
+  it("turns explicit unmet requirements into a participant-visible next step", () => {
+    const resolution = resolved();
+    resolution.r4 = "REQUIRES_EVIDENCE";
+    resolution.r5 = "UNKNOWN";
+    resolution.candidateAction = undefined;
+    resolution.unmetRequirementRefs = ["requirement:test:proof-of-role"];
+
+    const snapshot = assessBnrParticipantConformance(resolution);
+
+    expect(snapshot.experienceStatus).toBe("CONFORMANT");
+    expect(snapshot.actionability).toBe("KNOWN_BLOCKER");
+    expect(snapshot.required).toMatchObject({
+      outcome: "KNOWN_BLOCKER",
+      code: "REQUIREMENTS_EXPLICIT",
+    });
+    expect(snapshot.next).toMatchObject({
+      outcome: "KNOWN_BLOCKER",
+      code: "NEXT_SATISFY_REQUIREMENTS",
+    });
+    expect(snapshot.nextAction).toEqual({
+      state: "SATISFY_REQUIREMENTS",
+      executable: false,
+      candidateAction: undefined,
+      requirementRefs: ["requirement:test:proof-of-role", "evidence:test:identity"],
+    });
+  });
+
+  it("fails conformance when Registry says evidence is required but cannot identify it", () => {
+    const resolution = resolved();
+    resolution.r4 = "REQUIRES_EVIDENCE";
+    resolution.unmetRequirementRefs = [];
+    resolution.evidenceRequirementRefs = [];
+
+    const snapshot = assessBnrParticipantConformance(resolution);
+
+    expect(snapshot.experienceStatus).toBe("NON_CONFORMANT");
+    expect(snapshot.actionability).toBe("UNRESOLVED");
+    expect(snapshot.required.code).toBe("REQUIREMENTS_NOT_IDENTIFIED");
+    expect(snapshot.nextAction.state).toBe("UNRESOLVED");
+    expect(snapshot.unresolvedQuestions).toEqual(["R4", "R5"]);
+  });
+
+  it("treats an evidenced Registry denial as a clear answer rather than an unknown state", () => {
+    const resolution = resolved();
+    resolution.r3 = "DENIED";
+
+    const snapshot = assessBnrParticipantConformance(resolution);
+
+    expect(snapshot.experienceStatus).toBe("CONFORMANT");
+    expect(snapshot.actionability).toBe("DENIED");
+    expect(snapshot.applies).toMatchObject({
+      outcome: "DENIED",
+      code: "APPLICABILITY_DENIED",
+      refs: ["authority:test:participation"],
+    });
+    expect(snapshot.nextAction.state).toBe("DENIED");
+    expect(snapshot.nextAction.executable).toBe(false);
+  });
+
+  it("fails conformance when a Registry denial has no authority reference", () => {
+    const resolution = resolved();
+    resolution.r3 = "DENIED";
+    resolution.authorityRefs = [];
+
+    const snapshot = assessBnrParticipantConformance(resolution);
+
+    expect(snapshot.experienceStatus).toBe("NON_CONFORMANT");
+    expect(snapshot.actionability).toBe("UNRESOLVED");
+    expect(snapshot.applies.code).toBe("APPLICABILITY_DENIED_WITHOUT_AUTHORITY_REF");
+    expect(snapshot.unresolvedQuestions).toContain("R3");
+  });
+
+  it("surfaces Warden review and denial without leaking execution authority", () => {
+    const review = assessBnrParticipantConformance(resolved(), warden("REVIEW_REQUIRED"));
+    expect(review.experienceStatus).toBe("CONFORMANT");
+    expect(review.actionability).toBe("KNOWN_BLOCKER");
+    expect(review.nextAction.state).toBe("AWAIT_WARDEN_REVIEW");
+    expect(review.nextAction.executable).toBe(false);
+
+    const denied = assessBnrParticipantConformance(resolved(), warden("DENIED"));
+    expect(denied.experienceStatus).toBe("CONFORMANT");
+    expect(denied.actionability).toBe("DENIED");
+    expect(denied.nextAction).toMatchObject({
+      state: "DENIED",
+      executable: false,
+      reason: "scope_not_permitted",
+    });
+  });
+
+  it("fails conformance when R5 claims resolution but supplies no candidate action", () => {
+    const resolution = resolved();
+    resolution.candidateAction = undefined;
+
+    const snapshot = assessBnrParticipantConformance(resolution);
+
+    expect(snapshot.experienceStatus).toBe("NON_CONFORMANT");
+    expect(snapshot.actionability).toBe("UNRESOLVED");
+    expect(snapshot.next.code).toBe("NEXT_ACTION_MISSING");
+    expect(snapshot.unresolvedQuestions).toEqual(["R5"]);
+  });
+});

--- a/api/runtime/participant-conformance.ts
+++ b/api/runtime/participant-conformance.ts
@@ -1,0 +1,333 @@
+import type {
+  RegistryResolutionBundle,
+  RegistryResolutionStatus,
+  WardenAuthorizationResult,
+} from "./program-event-contract.js";
+
+export const BNR_PARTICIPANT_CONFORMANCE_VERSION =
+  "bnr.participant-conformance.v1" as const;
+
+export type ParticipantDimensionOutcome =
+  | "ANSWERED"
+  | "KNOWN_BLOCKER"
+  | "DENIED"
+  | "UNRESOLVED";
+
+export type ParticipantQuestion = "R1" | "R2" | "R3" | "R4" | "R5";
+
+export type ParticipantActionability =
+  | "EXECUTABLE"
+  | "KNOWN_BLOCKER"
+  | "DENIED"
+  | "UNRESOLVED";
+
+export type ParticipantNextActionState =
+  | "EXECUTE_AUTHORIZED_ACTION"
+  | "SATISFY_REQUIREMENTS"
+  | "AWAIT_WARDEN_AUTHORIZATION"
+  | "AWAIT_WARDEN_REVIEW"
+  | "DENIED"
+  | "UNRESOLVED";
+
+export interface ParticipantDimensionAssessment {
+  question: ParticipantQuestion;
+  outcome: ParticipantDimensionOutcome;
+  registryStatus: RegistryResolutionStatus;
+  code: string;
+  refs: string[];
+}
+
+export interface ParticipantNextAction {
+  state: ParticipantNextActionState;
+  executable: boolean;
+  candidateAction?: string;
+  requirementRefs: string[];
+  decisionRef?: string;
+  reason?: string;
+}
+
+export interface BnrParticipantConformanceSnapshotV1 {
+  contractVersion: typeof BNR_PARTICIPANT_CONFORMANCE_VERSION;
+  requestRef: string;
+  experienceStatus: "CONFORMANT" | "NON_CONFORMANT";
+  actionability: ParticipantActionability;
+  recognized: ParticipantDimensionAssessment;
+  connected: ParticipantDimensionAssessment;
+  applies: ParticipantDimensionAssessment;
+  required: ParticipantDimensionAssessment;
+  next: ParticipantDimensionAssessment;
+  nextAction: ParticipantNextAction;
+  unresolvedQuestions: ParticipantQuestion[];
+}
+
+function assessment(
+  question: ParticipantQuestion,
+  outcome: ParticipantDimensionOutcome,
+  registryStatus: RegistryResolutionStatus,
+  code: string,
+  refs: string[] = [],
+): ParticipantDimensionAssessment {
+  return {
+    question,
+    outcome,
+    registryStatus,
+    code,
+    refs: [...new Set(refs)],
+  };
+}
+
+function isRegistryDenial(status: RegistryResolutionStatus): boolean {
+  return status === "DENIED" || status === "EXPIRED" || status === "REVOKED";
+}
+
+function explicitRequirementRefs(resolution: RegistryResolutionBundle): string[] {
+  return [
+    ...new Set([
+      ...resolution.unmetRequirementRefs,
+      ...resolution.evidenceRequirementRefs,
+    ]),
+  ];
+}
+
+/**
+ * Converts Registry R1-R5 plus an optional Warden decision into the five
+ * participant-visible answers BNR must be able to present.
+ *
+ * This function is descriptive only. It never grants authority. A resolved
+ * R5 candidate remains non-executable until Warden explicitly authorizes it.
+ */
+export function assessBnrParticipantConformance(
+  resolution: RegistryResolutionBundle,
+  wardenDecision?: WardenAuthorizationResult,
+): BnrParticipantConformanceSnapshotV1 {
+  const recognized =
+    resolution.r1 === "RESOLVED"
+      ? assessment("R1", "ANSWERED", resolution.r1, "IDENTITY_RECOGNIZED")
+      : assessment("R1", "UNRESOLVED", resolution.r1, `IDENTITY_${resolution.r1}`);
+
+  const connected =
+    resolution.r2 === "RESOLVED"
+      ? assessment("R2", "ANSWERED", resolution.r2, "RELATIONSHIP_RESOLVED")
+      : assessment("R2", "UNRESOLVED", resolution.r2, `RELATIONSHIP_${resolution.r2}`);
+
+  let applies: ParticipantDimensionAssessment;
+  if (resolution.r3 === "RESOLVED") {
+    applies = assessment(
+      "R3",
+      "ANSWERED",
+      resolution.r3,
+      "APPLICABLE_AUTHORITY_RESOLVED",
+      resolution.authorityRefs,
+    );
+  } else if (resolution.r3 === "REQUIRES_AUTHORIZATION") {
+    applies = assessment(
+      "R3",
+      "KNOWN_BLOCKER",
+      resolution.r3,
+      "WARDEN_AUTHORIZATION_REQUIRED",
+      resolution.authorityRefs,
+    );
+  } else if (isRegistryDenial(resolution.r3) && resolution.authorityRefs.length > 0) {
+    applies = assessment(
+      "R3",
+      "DENIED",
+      resolution.r3,
+      `APPLICABILITY_${resolution.r3}`,
+      resolution.authorityRefs,
+    );
+  } else {
+    applies = assessment(
+      "R3",
+      "UNRESOLVED",
+      resolution.r3,
+      isRegistryDenial(resolution.r3)
+        ? `APPLICABILITY_${resolution.r3}_WITHOUT_AUTHORITY_REF`
+        : `APPLICABILITY_${resolution.r3}`,
+      resolution.authorityRefs,
+    );
+  }
+
+  const requirementRefs = explicitRequirementRefs(resolution);
+  let required: ParticipantDimensionAssessment;
+  if (resolution.r4 === "RESOLVED" && resolution.unmetRequirementRefs.length === 0) {
+    required = assessment(
+      "R4",
+      "ANSWERED",
+      resolution.r4,
+      "REQUIREMENTS_SATISFIED",
+      resolution.evidenceRequirementRefs,
+    );
+  } else if (
+    (resolution.r4 === "REQUIRES_EVIDENCE" || resolution.unmetRequirementRefs.length > 0) &&
+    requirementRefs.length > 0
+  ) {
+    required = assessment(
+      "R4",
+      "KNOWN_BLOCKER",
+      resolution.r4,
+      "REQUIREMENTS_EXPLICIT",
+      requirementRefs,
+    );
+  } else {
+    required = assessment(
+      "R4",
+      "UNRESOLVED",
+      resolution.r4,
+      resolution.r4 === "REQUIRES_EVIDENCE"
+        ? "REQUIREMENTS_NOT_IDENTIFIED"
+        : `REQUIREMENTS_${resolution.r4}`,
+      requirementRefs,
+    );
+  }
+
+  let next: ParticipantDimensionAssessment;
+  let nextAction: ParticipantNextAction;
+
+  if (required.outcome === "KNOWN_BLOCKER") {
+    next = assessment(
+      "R5",
+      "KNOWN_BLOCKER",
+      resolution.r5,
+      "NEXT_SATISFY_REQUIREMENTS",
+      requirementRefs,
+    );
+    nextAction = {
+      state: "SATISFY_REQUIREMENTS",
+      executable: false,
+      candidateAction: resolution.candidateAction,
+      requirementRefs,
+    };
+  } else if (required.outcome === "UNRESOLVED") {
+    next = assessment("R5", "UNRESOLVED", resolution.r5, "NEXT_BLOCKED_BY_UNKNOWN_REQUIREMENTS");
+    nextAction = {
+      state: "UNRESOLVED",
+      executable: false,
+      requirementRefs,
+      reason: required.code,
+    };
+  } else if (applies.outcome === "DENIED") {
+    next = assessment("R5", "DENIED", resolution.r5, "NEXT_DENIED_BY_REGISTRY", resolution.authorityRefs);
+    nextAction = {
+      state: "DENIED",
+      executable: false,
+      candidateAction: resolution.candidateAction,
+      requirementRefs,
+      reason: applies.code,
+    };
+  } else if (applies.outcome === "UNRESOLVED") {
+    next = assessment("R5", "UNRESOLVED", resolution.r5, "NEXT_BLOCKED_BY_UNKNOWN_APPLICABILITY");
+    nextAction = {
+      state: "UNRESOLVED",
+      executable: false,
+      requirementRefs,
+      reason: applies.code,
+    };
+  } else if (resolution.r5 !== "RESOLVED" || !resolution.candidateAction) {
+    next = assessment(
+      "R5",
+      "UNRESOLVED",
+      resolution.r5,
+      resolution.r5 === "RESOLVED" ? "NEXT_ACTION_MISSING" : `NEXT_${resolution.r5}`,
+    );
+    nextAction = {
+      state: "UNRESOLVED",
+      executable: false,
+      requirementRefs,
+      reason: next.code,
+    };
+  } else if (!wardenDecision) {
+    next = assessment(
+      "R5",
+      "KNOWN_BLOCKER",
+      resolution.r5,
+      "NEXT_AWAIT_WARDEN_AUTHORIZATION",
+      resolution.authorityRefs,
+    );
+    nextAction = {
+      state: "AWAIT_WARDEN_AUTHORIZATION",
+      executable: false,
+      candidateAction: resolution.candidateAction,
+      requirementRefs,
+    };
+  } else if (wardenDecision.outcome === "AUTHORIZED") {
+    next = assessment(
+      "R5",
+      "ANSWERED",
+      resolution.r5,
+      "NEXT_AUTHORIZED",
+      resolution.authorityRefs,
+    );
+    nextAction = {
+      state: "EXECUTE_AUTHORIZED_ACTION",
+      executable: true,
+      candidateAction: resolution.candidateAction,
+      requirementRefs,
+      decisionRef: wardenDecision.decisionRef,
+      reason: wardenDecision.reason,
+    };
+  } else if (wardenDecision.outcome === "REVIEW_REQUIRED") {
+    next = assessment(
+      "R5",
+      "KNOWN_BLOCKER",
+      resolution.r5,
+      "NEXT_AWAIT_WARDEN_REVIEW",
+      resolution.authorityRefs,
+    );
+    nextAction = {
+      state: "AWAIT_WARDEN_REVIEW",
+      executable: false,
+      candidateAction: resolution.candidateAction,
+      requirementRefs,
+      decisionRef: wardenDecision.decisionRef,
+      reason: wardenDecision.reason,
+    };
+  } else {
+    next = assessment(
+      "R5",
+      "DENIED",
+      resolution.r5,
+      "NEXT_DENIED_BY_WARDEN",
+      resolution.authorityRefs,
+    );
+    nextAction = {
+      state: "DENIED",
+      executable: false,
+      candidateAction: resolution.candidateAction,
+      requirementRefs,
+      decisionRef: wardenDecision.decisionRef,
+      reason: wardenDecision.reason,
+    };
+  }
+
+  const dimensions = [recognized, connected, applies, required, next];
+  const unresolvedQuestions = dimensions
+    .filter((dimension) => dimension.outcome === "UNRESOLVED")
+    .map((dimension) => dimension.question);
+
+  const experienceStatus = unresolvedQuestions.length === 0 ? "CONFORMANT" : "NON_CONFORMANT";
+
+  let actionability: ParticipantActionability;
+  if (unresolvedQuestions.length > 0) {
+    actionability = "UNRESOLVED";
+  } else if (applies.outcome === "DENIED" || next.outcome === "DENIED") {
+    actionability = "DENIED";
+  } else if (nextAction.executable) {
+    actionability = "EXECUTABLE";
+  } else {
+    actionability = "KNOWN_BLOCKER";
+  }
+
+  return {
+    contractVersion: BNR_PARTICIPANT_CONFORMANCE_VERSION,
+    requestRef: resolution.requestRef,
+    experienceStatus,
+    actionability,
+    recognized,
+    connected,
+    applies,
+    required,
+    next,
+    nextAction,
+    unresolvedQuestions,
+  };
+}

--- a/docs/bnr/BNR-PARTICIPANT-CONFORMANCE-001.md
+++ b/docs/bnr/BNR-PARTICIPANT-CONFORMANCE-001.md
@@ -1,0 +1,112 @@
+# BNR-PARTICIPANT-CONFORMANCE-001
+
+## Purpose
+
+Define the minimum participant-visible success condition for a BNR node.
+
+A node is not conformant merely because its Registry, workflow engine, database, agent or UI is online. It is conformant when a participant can receive an intelligible answer to the five canonical Registry questions without collapsing routing into authority.
+
+## Five participant outcomes
+
+| Registry question | Participant outcome | Minimum conformance condition |
+| --- | --- | --- |
+| R1 — WHO | **I am recognized.** | Identity is explicitly resolved. |
+| R2 — HOW CONNECTED | **My relationship/context is understood.** | Relationship/context is explicitly resolved. |
+| R3 — WHAT APPLIES | **I can see what governs this participation.** | Applicability is resolved, authorization is explicitly required, or a denial is tied to an authority reference. |
+| R4 — WHAT IS REQUIRED | **I know what remains required.** | Requirements are satisfied, or every blocker is named by requirement/evidence reference. |
+| R5 — WHAT NEXT | **I know the next permissible step.** | The next state is explicit: satisfy requirements, await Warden, await review, accept denial, or execute an authorized candidate action. |
+
+## Critical separation
+
+```text
+R5 CANDIDATE ACTION != WARDEN AUTHORIZATION != EXECUTION AUTHORITY
+```
+
+A Registry-resolved candidate action is routing/context. It is never executable merely because R5 resolved it.
+
+Only an explicit Warden `AUTHORIZED` decision may make the candidate action executable.
+
+## Experience conformance vs actionability
+
+The contract deliberately separates two questions.
+
+### Experience conformance
+
+`CONFORMANT` means the participant has an intelligible answer for R1-R5.
+
+A conformant experience may still end in:
+
+- a known requirement blocker;
+- Warden review;
+- an explicit denial;
+- an authorized executable action.
+
+A participant does not need to be permitted to act for the node to explain the state correctly.
+
+### Actionability
+
+The runtime classifies present actionability as:
+
+- `EXECUTABLE` — Warden has explicitly authorized the R5 candidate;
+- `KNOWN_BLOCKER` — the next step is understood but cannot yet execute;
+- `DENIED` — Registry/Warden has explicitly denied the participation path;
+- `UNRESOLVED` — one or more canonical questions cannot yet be answered.
+
+## Fail-closed rules
+
+1. `R1 != RESOLVED` is non-conformant.
+2. `R2 != RESOLVED` is non-conformant.
+3. `R3 = DENIED|EXPIRED|REVOKED` without an authority reference is non-conformant.
+4. `R4 = REQUIRES_EVIDENCE` without explicit requirement/evidence references is non-conformant.
+5. `R5 = RESOLVED` without a `candidateAction` is non-conformant.
+6. R5 without a Warden decision remains non-executable.
+7. Warden `REVIEW_REQUIRED` remains non-executable.
+8. Warden `DENIED` remains non-executable.
+
+## Requirement-first next action
+
+If R4 identifies explicit unmet requirements, the participant-visible next step is `SATISFY_REQUIREMENTS` even when the final R5 candidate cannot yet be resolved.
+
+This is descriptive guidance, not execution authority. It prevents the participant from receiving a meaningless `UNKNOWN` when the system already knows the concrete blocker.
+
+## Runtime object
+
+Implementation: `api/runtime/participant-conformance.ts`
+
+Version:
+
+```text
+bnr.participant-conformance.v1
+```
+
+The output contains:
+
+- `experienceStatus`;
+- `actionability`;
+- assessments for `recognized`, `connected`, `applies`, `required`, and `next`;
+- a non-authoritative participant `nextAction` description;
+- `unresolvedQuestions` for operational remediation.
+
+## Alpha Node acceptance gate
+
+For `ALPHA-NODE-001`, the first issuance should not be considered participant-ready merely because data has reached a projection.
+
+A bounded VSR/Front Gate surface should be capable of producing this conformance snapshot from Registry R1-R5 plus the relevant Warden decision.
+
+The minimum acceptance rule is:
+
+```text
+NO PARTICIPANT SURFACE GRANT
+UNLESS
+R1-R5 CAN BE EXPLAINED
+AND
+ANY EXECUTABLE ACTION CARRIES EXPLICIT WARDEN AUTHORIZATION
+```
+
+## Future BNR node inheritance
+
+Every future BNR node may use different infrastructure, databases, agents, models or interfaces, but this semantic participant contract should remain stable.
+
+The implementation may evolve. The participant invariant should not:
+
+> I am recognized; my relationship is understood; I can see what applies; I know what is required; and I know what I may do next.


### PR DESCRIPTION
## Objective

Turns the BNR participant success condition into an executable conformance contract on top of the governed Program/Event runtime in #28.

Participant invariant:

> I am recognized; my relationship is understood; I can see what applies; I know what is required; and I know what I may do next.

## Added

- `api/runtime/participant-conformance.ts`
  - pure R1-R5 + optional Warden assessment;
  - separates `experienceStatus` from `actionability`;
  - explicit participant outcomes for recognition, relationship, applicability, requirements and next action;
  - fail-closed handling for unnamed evidence requirements, unexplained Registry denials and missing R5 candidate actions;
  - no execution authority from R5 alone.
- `api/runtime/participant-conformance.test.ts`
  - Warden-authorized executable path;
  - R5 candidate without Warden remains non-executable;
  - explicit unmet requirements become the participant-visible next step;
  - unnamed evidence requirement fails conformance;
  - evidenced Registry denial is intelligible but non-executable;
  - denial without authority reference fails conformance;
  - Warden review/denial remain non-executable;
  - missing R5 candidate fails conformance.
- `docs/bnr/BNR-PARTICIPANT-CONFORMANCE-001.md`
  - semantic contract and Alpha Node acceptance gate.
- focused CI workflow.

## Critical invariant

```text
R5 CANDIDATE ACTION != WARDEN AUTHORIZATION != EXECUTION AUTHORITY
```

A node can be experience-conformant while blocked, under review or explicitly denied. Only Warden `AUTHORIZED` makes the candidate action executable.

## Alpha Node use

This is intended as the participant-facing acceptance gate for first issuance: a VSR/Front Gate surface grant should not be considered participant-ready unless it can explain R1-R5 and any executable action carries explicit Warden authorization.

## Scope boundary

- no live Registry writes;
- no provider/database writes;
- no new authority source;
- no change to Warden semantics;
- no change to RiverOS evidence truth;
- no settlement/economic effect;
- stacked over #28 and should not be merged independently of its Program/Event contract dependency.
