### PR TITLE
Add BAG-LOCK device execution interlock

### DIFF
--- a/api/runtime/program-event-contract.ts
+++ b/api/runtime/program-event-contract.ts
@@ -14,6 +14,26 @@ export type RegistryResolutionStatus =
   | "SUPERSEDED"
   | "UNSUPPORTED";
 
+export type DeviceSecurityState =
+  | "ACTIVE"
+  | "BAG_LOCK_REQUESTED"
+  | "SEALED"
+  | "SEALED_ALERT"
+  | "UNSEAL_PENDING"
+  | "WARDEN_REAUTH"
+  | "CONTROLLED_RECONNECT"
+  | "RECOVERY_REQUIRED";
+
+export type DeviceSecurityAssuranceLevel = "L0" | "L1" | "L2" | "L3" | "L4";
+
+export interface DeviceSecurityContext {
+  deviceRef: string;
+  state: DeviceSecurityState;
+  policyRef?: string;
+  evidenceRef?: string;
+  assuranceLevel?: DeviceSecurityAssuranceLevel;
+}
+
 export type ProgramState =
   | "DRAFT"
   | "READY_FOR_RESOLUTION"
@@ -75,6 +95,7 @@ export interface EventContractV1 {
   actingCapacityRef?: string;
   placeRef?: string;
   thingRef: string;
+  executionDeviceRef?: string;
   requestedCapability: string;
   dependencyRefs: string[];
   constraintRefs: string[];
@@ -96,6 +117,7 @@ export interface RegistryResolutionBundle {
   evidenceRequirementRefs: string[];
   expectedEffectRefs: string[];
   economicContextRefs: string[];
+  deviceSecurityContext?: DeviceSecurityContext;
 }
 
 export interface PreparedProgramAction {
@@ -150,6 +172,7 @@ export interface EconomicConsequenceReceipt {
 
 export type ProgramTraceStep =
   | "RESOLVE_R1_R5"
+  | "CHECK_DEVICE_SECURITY"
   | "PREPARE_ACTION"
   | "WARDEN_AUTHORIZE"
   | "RIVER_RESERVE"

--- a/api/runtime/program-runner.test.ts
+++ b/api/runtime/program-runner.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   PROGRAM_EVENT_CONTRACT_VERSION,
+  type DeviceSecurityState,
   type EventContractV1,
   type ProgramContractV1,
   type ProgramExecutionGateway,
@@ -136,6 +137,24 @@ const input = () => ({
   idempotencyKey: "idem:test:1",
 });
 
+function deviceBoundInput() {
+  const value = input();
+  value.event.executionDeviceRef = "device:test:1";
+  return value;
+}
+
+function withDeviceState(state: DeviceSecurityState): RegistryResolutionBundle {
+  const value = resolved();
+  value.deviceSecurityContext = {
+    deviceRef: "device:test:1",
+    state,
+    policyRef: "policy:bag-lock:v1",
+    evidenceRef: "river:bag-lock-state:test:1",
+    assuranceLevel: "L1",
+  };
+  return value;
+}
+
 describe("Synnergyze Program/Event runtime v1", () => {
   it("executes the governed happy path in canonical order", async () => {
     const { gateway, calls } = testGateway();
@@ -237,6 +256,73 @@ describe("Synnergyze Program/Event runtime v1", () => {
       "authorize:ROUTE_TO_TEST_CAPABILITY",
       "reserve",
       "execute",
+    ]);
+  });
+
+  it("fails closed when a device-bound event has no resolved security state", async () => {
+    const { gateway, calls } = testGateway();
+    const output = await runProgramEvent(deviceBoundInput(), gateway);
+
+    expect(output.state).toBe("BLOCKED_REQUIREMENT");
+    expect(output.reason).toBe("DEVICE_SECURITY_STATE_UNRESOLVED");
+    expect(calls).toEqual(["resolve"]);
+    expect(output.trace.map((entry) => entry.step)).toEqual([
+      "RESOLVE_R1_R5",
+      "CHECK_DEVICE_SECURITY",
+    ]);
+  });
+
+  it("fails closed when the resolved security context belongs to another device", async () => {
+    const resolution = withDeviceState("ACTIVE");
+    resolution.deviceSecurityContext!.deviceRef = "device:test:other";
+    const { gateway, calls } = testGateway({ resolution });
+    const output = await runProgramEvent(deviceBoundInput(), gateway);
+
+    expect(output.state).toBe("BLOCKED_REQUIREMENT");
+    expect(output.reason).toBe("DEVICE_SECURITY_CONTEXT_MISMATCH");
+    expect(calls).toEqual(["resolve"]);
+  });
+
+  for (const state of [
+    "BAG_LOCK_REQUESTED",
+    "SEALED",
+    "SEALED_ALERT",
+    "UNSEAL_PENDING",
+    "WARDEN_REAUTH",
+    "CONTROLLED_RECONNECT",
+    "RECOVERY_REQUIRED",
+  ] as const) {
+    it(`blocks ordinary device-bound execution while device state is ${state}`, async () => {
+      const { gateway, calls } = testGateway({ resolution: withDeviceState(state) });
+      const output = await runProgramEvent(deviceBoundInput(), gateway);
+
+      expect(output.state).toBe("BLOCKED_REQUIREMENT");
+      expect(output.eventState).toBe("BLOCKED_REQUIREMENT");
+      expect(output.reason).toBe(`DEVICE_SECURITY_STATE_${state}`);
+      expect(calls).toEqual(["resolve"]);
+      expect(calls).not.toContain("execute");
+    });
+  }
+
+  it("allows a device-bound event to continue only when the same device resolves ACTIVE", async () => {
+    const { gateway, calls } = testGateway({ resolution: withDeviceState("ACTIVE") });
+    const output = await runProgramEvent(deviceBoundInput(), gateway);
+
+    expect(output.state).toBe("SETTLED_RECONCILED");
+    expect(calls).toContain("authorize:ROUTE_TO_TEST_CAPABILITY");
+    expect(calls).toContain("execute");
+    expect(output.trace.map((entry) => entry.step)).toEqual([
+      "RESOLVE_R1_R5",
+      "CHECK_DEVICE_SECURITY",
+      "PREPARE_ACTION",
+      "WARDEN_AUTHORIZE",
+      "RIVER_RESERVE",
+      "EXECUTE_CAPABILITY",
+      "CONFIRM_RESULT",
+      "RIVER_SEAL",
+      "RECORD_EFFECT",
+      "ECONOMIC_CONSEQUENCE",
+      "UPDATE_STATE",
     ]);
   });
 });

--- a/api/runtime/program-runner.ts
+++ b/api/runtime/program-runner.ts
@@ -78,6 +78,35 @@ export async function runProgramEvent(
     });
   }
 
+  if (event.executionDeviceRef) {
+    const deviceSecurity = resolution.deviceSecurityContext;
+    trace(
+      entries,
+      "CHECK_DEVICE_SECURITY",
+      "READY_FOR_RESOLUTION",
+      event.executionDeviceRef,
+      deviceSecurity?.state ?? "UNRESOLVED",
+    );
+
+    if (!deviceSecurity) {
+      return result(program, event, "BLOCKED_REQUIREMENT", "BLOCKED_REQUIREMENT", entries, {
+        reason: "DEVICE_SECURITY_STATE_UNRESOLVED",
+      });
+    }
+
+    if (deviceSecurity.deviceRef !== event.executionDeviceRef) {
+      return result(program, event, "BLOCKED_REQUIREMENT", "BLOCKED_REQUIREMENT", entries, {
+        reason: "DEVICE_SECURITY_CONTEXT_MISMATCH",
+      });
+    }
+
+    if (deviceSecurity.state !== "ACTIVE") {
+      return result(program, event, "BLOCKED_REQUIREMENT", "BLOCKED_REQUIREMENT", entries, {
+        reason: `DEVICE_SECURITY_STATE_${deviceSecurity.state}`,
+      });
+    }
+  }
+
   if (resolution.r4 === "REQUIRES_EVIDENCE" || resolution.unmetRequirementRefs.length > 0) {
     return result(program, event, "BLOCKED_REQUIREMENT", "BLOCKED_REQUIREMENT", entries, {
       reason: resolution.unmetRequirementRefs.length


### PR DESCRIPTION
## Objective

Adds the first Synnergyze runtime interlock for `BAG-LOCK-001` without expanding Synnergyze into device-security authority or pretending application code can close physical radios/ports.

This PR is intentionally stacked on PR #28 (`agent/program-event-runtime-v1-current`).

## Behavior

For an Event that declares `executionDeviceRef`:

1. Registry/context resolution must provide a `DeviceSecurityContext`.
2. The resolved security context must belong to the exact same device reference.
3. Ordinary Program/Event execution proceeds only when the device security state is `ACTIVE`.
4. Missing state, mismatched device context, or any non-`ACTIVE` BAG-LOCK state returns `BLOCKED_REQUIREMENT` before Warden authorization, River reservation, connector execution, Effect or economics.

Blocked states include:

`BAG_LOCK_REQUESTED | SEALED | SEALED_ALERT | UNSEAL_PENDING | WARDEN_REAUTH | CONTROLLED_RECONNECT | RECOVERY_REQUIRED`

Recovery/unseal is deliberately **not** routed through this ordinary material-event path. It remains a separate privileged device/Warden recovery boundary.

## Added contract fields

- `DeviceSecurityState`;
- `DeviceSecurityAssuranceLevel` (`L0`–`L4`);
- `DeviceSecurityContext`;
- optional `EventContractV1.executionDeviceRef`;
- optional `RegistryResolutionBundle.deviceSecurityContext`;
- `CHECK_DEVICE_SECURITY` trace step.

## Fail-closed tests

- device-bound execution with unresolved security state is blocked;
- security context for a different device is blocked;
- every non-`ACTIVE` BAG-LOCK state is blocked before Warden/execution;
- matching device + `ACTIVE` continues through the existing governed execution path;
- non-device-bound events preserve existing Program/Event behavior.

## Authority boundary

- Genesis/device substrate enforces hardware/OS controls;
- Warden remains authorization authority;
- Registry/context resolution supplies the referenced device security state;
- Synnergyze only treats that state as a hard pre-execution constraint;
- RiverOS remains evidence continuity;
- this PR performs no live host, port, radio or database mutation.

Dependencies / lineage:

- `Believers-common-group/SynergyzeGovernance#19` — BAG-LOCK governance contract;
- `Believers-common-group/DigitalMe#21` — provider-neutral BAG-LOCK contract/conformance;
- `Believers-common-group/genesis-stack#24` — Genesis BAG-LOCK source/P0 gates;
- base `Believers-common-group/mcp-node-synnergyze#28` — governed Program/Event runtime.
