### PR TITLE
feat(alpha): add governed Compute Plane and Apple MPP backend scaffold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,19 @@ CRON_SECRET=<optional-replace-with-long-random-secret>
 # not production gates and must never be hard-coded into repository source.
 SUPABASE_URL=https://<project-ref>.supabase.co
 SUPABASE_PUBLISHABLE_KEY=sb_publishable_<replace-me>
+
+# ALPHA-RELEASE-003 governed Compute Plane.
+# ALPHA-NODE-001 remains the authority-containing environment. Backends are capabilities,
+# never authorities. The default provider is deliberately none so execution fails closed
+# until Warden authorizes and resolves a permitted capability.
+COMPUTE_PLANE_MODE=governed
+COMPUTE_DEFAULT_PROVIDER=none
+COMPUTE_REQUIRE_WARDEN_GRANT=true
+COMPUTE_EVIDENCE_MODE=envelope
+
+# Apple Metal 4 / Metal Performance Primitives runner.
+# Do not enable on the Ubuntu Alpha control host. Enable only after a separately enrolled
+# Apple-silicon runner passes scripts/bootstrap-apple-mpp-runner.sh and the Warden proof.
+COMPUTE_APPLE_MPP_ENABLED=false
+COMPUTE_APPLE_MPP_RUNNER_URL=
+COMPUTE_APPLE_MPP_RUNNER_ID=

--- a/api/compute-plane.test.ts
+++ b/api/compute-plane.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveComputePlaneStatus } from "./compute-plane.ts";
+
+describe("ALPHA-NODE-001 compute plane", () => {
+  it("defaults to governed, Warden-required, no implicit provider", () => {
+    const status = resolveComputePlaneStatus({});
+
+    expect(status.ok).toBe(true);
+    expect(status.mode).toBe("governed");
+    expect(status.require_warden_grant).toBe(true);
+    expect(status.default_provider).toBeNull();
+    expect(status.apple_mpp.enabled).toBe(false);
+    expect(status.apple_mpp.status).toBe("DISABLED");
+  });
+
+  it("fails closed when MPP is enabled without a complete runner binding", () => {
+    const status = resolveComputePlaneStatus({
+      COMPUTE_APPLE_MPP_ENABLED: "true",
+      COMPUTE_APPLE_MPP_RUNNER_ID: "GENESIS-APPLE-RUNNER-001",
+    });
+
+    expect(status.apple_mpp.runner_configured).toBe(false);
+    expect(status.apple_mpp.status).toBe("MISCONFIGURED_FAIL_CLOSED");
+  });
+
+  it("never reports MPP ready from environment configuration alone", () => {
+    const status = resolveComputePlaneStatus({
+      COMPUTE_PLANE_MODE: "governed",
+      COMPUTE_DEFAULT_PROVIDER: "none",
+      COMPUTE_REQUIRE_WARDEN_GRANT: "true",
+      COMPUTE_EVIDENCE_MODE: "envelope",
+      COMPUTE_APPLE_MPP_ENABLED: "true",
+      COMPUTE_APPLE_MPP_RUNNER_URL: "https://runner.invalid",
+      COMPUTE_APPLE_MPP_RUNNER_ID: "GENESIS-APPLE-RUNNER-001",
+    });
+
+    expect(status.ok).toBe(true);
+    expect(status.apple_mpp.runner_configured).toBe(true);
+    expect(status.apple_mpp.status).toBe("CONFIGURED_AWAITING_WARDEN_PROOF");
+  });
+
+  it("marks the control plane unhealthy if Warden grants are disabled", () => {
+    const status = resolveComputePlaneStatus({
+      COMPUTE_REQUIRE_WARDEN_GRANT: "false",
+    });
+
+    expect(status.ok).toBe(false);
+  });
+});

--- a/api/compute-plane.ts
+++ b/api/compute-plane.ts
@@ -1,0 +1,69 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+export type ComputePlaneStatus = {
+  ok: boolean;
+  node_id: "ALPHA-NODE-001";
+  registry_object: "REG-COMPUTE-001";
+  mode: string;
+  default_provider: string | null;
+  require_warden_grant: boolean;
+  evidence_mode: string;
+  apple_mpp: {
+    enabled: boolean;
+    runner_configured: boolean;
+    status:
+      | "DISABLED"
+      | "MISCONFIGURED_FAIL_CLOSED"
+      | "CONFIGURED_AWAITING_WARDEN_PROOF";
+  };
+};
+
+function envFlag(value: string | undefined, failClosedDefault: boolean): boolean {
+  if (value === undefined || value === "") return failClosedDefault;
+  return value.toLowerCase() === "true";
+}
+
+export function resolveComputePlaneStatus(
+  env: NodeJS.ProcessEnv = process.env,
+): ComputePlaneStatus {
+  const mode = env.COMPUTE_PLANE_MODE || "governed";
+  const defaultProviderRaw = env.COMPUTE_DEFAULT_PROVIDER || "none";
+  const defaultProvider = defaultProviderRaw === "none" ? null : defaultProviderRaw;
+  const requireWardenGrant = envFlag(env.COMPUTE_REQUIRE_WARDEN_GRANT, true);
+  const evidenceMode = env.COMPUTE_EVIDENCE_MODE || "envelope";
+
+  const mppEnabled = envFlag(env.COMPUTE_APPLE_MPP_ENABLED, false);
+  const runnerConfigured = Boolean(
+    env.COMPUTE_APPLE_MPP_RUNNER_URL && env.COMPUTE_APPLE_MPP_RUNNER_ID,
+  );
+
+  let mppStatus: ComputePlaneStatus["apple_mpp"]["status"] = "DISABLED";
+  if (mppEnabled && !runnerConfigured) {
+    mppStatus = "MISCONFIGURED_FAIL_CLOSED";
+  } else if (mppEnabled && runnerConfigured) {
+    mppStatus = "CONFIGURED_AWAITING_WARDEN_PROOF";
+  }
+
+  return {
+    ok: mode === "governed" && requireWardenGrant && defaultProvider === null,
+    node_id: "ALPHA-NODE-001",
+    registry_object: "REG-COMPUTE-001",
+    mode,
+    default_provider: defaultProvider,
+    require_warden_grant: requireWardenGrant,
+    evidence_mode: evidenceMode,
+    apple_mpp: {
+      enabled: mppEnabled,
+      runner_configured: runnerConfigured,
+      status: mppStatus,
+    },
+  };
+}
+
+export default function handler(_request: IncomingMessage, response: ServerResponse) {
+  const status = resolveComputePlaneStatus();
+  response.statusCode = status.ok ? 200 : 503;
+  response.setHeader("content-type", "application/json; charset=utf-8");
+  response.setHeader("cache-control", "no-store");
+  response.end(JSON.stringify(status));
+}

--- a/config/compute/ALPHA-NODE-001.compute.json
+++ b/config/compute/ALPHA-NODE-001.compute.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "1.0",
+  "registry_object": "REG-COMPUTE-001",
+  "release": "ALPHA-RELEASE-003",
+  "node_id": "ALPHA-NODE-001",
+  "mode": "governed",
+  "default_provider": null,
+  "require_warden_grant": true,
+  "evidence_mode": "envelope",
+  "fallback_policy": "explicit-grant-only",
+  "providers": [
+    {
+      "capability_id": "ALPHA-COMPUTE-CPU-001",
+      "provider": "cpu-local",
+      "execution_class": "cpu",
+      "runtime": "node",
+      "hardware_family": "alpha-control-host",
+      "locality": "alpha-node",
+      "status": "CONTROL_PLANE_ONLY",
+      "supported_datatypes": [],
+      "supported_operations": [],
+      "trust": {
+        "attestation_required": true
+      },
+      "warden": {
+        "required": true
+      },
+      "evidence": {
+        "mode": "envelope"
+      },
+      "version": "1"
+    },
+    {
+      "capability_id": "ALPHA-COMPUTE-APPLE-MPP-001",
+      "provider": "apple-mpp-local",
+      "execution_class": "gpu-neural-accelerator",
+      "runtime": "metal4-mpp",
+      "hardware_family": "apple-m5",
+      "locality": "enrolled-edge-runner",
+      "status": "UNAVAILABLE_UNTIL_RUNNER_ENROLLED",
+      "supported_datatypes": ["fp16"],
+      "supported_operations": ["tensor", "gemm", "fused-kernel"],
+      "trust": {
+        "attestation_required": true
+      },
+      "warden": {
+        "required": true
+      },
+      "evidence": {
+        "mode": "envelope"
+      },
+      "version": "1"
+    }
+  ]
+}

--- a/docs/alpha-node/REG-COMPUTE-001.md
+++ b/docs/alpha-node/REG-COMPUTE-001.md
@@ -1,0 +1,109 @@
+# REG-COMPUTE-001 — Compute Capability Registry
+
+Status: `ALPHA-RELEASE-003 / FIRST-SLICE`
+Scope: `ALPHA-NODE-001` only
+Authority boundary: `Registry + Warden`
+
+## Purpose
+
+Introduce a hardware-neutral Compute Plane below the governed cognition layer. The Compute Plane describes where an authorized computation may run; it does not grant authority, choose legal purpose, or become a source of Registry truth.
+
+Canonical separation:
+
+`ENTITY != AGENT != MODEL != COMPUTE BACKEND != AUTHORITY`
+
+The current Apple reference backend is Metal 4 + Metal Performance Primitives (MPP) Tensor Ops. MPP is treated as a replaceable execution backend, not as an Alpha, Genesis, Warden, RiverOS, or Synnergyze dependency.
+
+## Placement
+
+```text
+DigitalMe
+  -> Registry
+  -> Warden
+  -> Agent / Cerebral / Model
+  -> REG-COMPUTE-001
+  -> Warden Compute Grant
+  -> Compute Orchestrator
+  -> Execution Adapter
+  -> MPP | CPU | future CUDA/ROCm/NPU/remote
+  -> Silicon
+  -> Result
+  -> Warden
+  -> RiverOS evidence envelope
+  -> Registry Effect
+```
+
+## Alpha first-slice rules
+
+1. `ALPHA-NODE-001` remains the containing governance/runtime environment. This work does not promote or rename Alpha as BNR.
+2. The Ubuntu Alpha VM is the control-plane host. Apple MPP must not be installed or emulated there.
+3. Apple MPP execution is optional and fail-closed. It becomes available only when a separately provisioned Apple-silicon runner passes the native readiness probe and is explicitly enabled.
+4. No compute request may be dispatched merely because a backend is available. A valid Warden compute grant is a precondition.
+5. Backend configuration may contain capability metadata only. Secrets, model payloads, participant data, and raw Warden credentials are forbidden in the registry manifest.
+6. RiverOS records the governed compute envelope (principal, grant, model, backend, timestamps, result/effect references), not low-level tensor operations.
+7. Provider-specific tuning parameters belong inside the provider adapter and must not leak into Registry identity or Warden policy semantics.
+8. A provider failure must not silently fall back to another provider unless the grant explicitly permits a fallback class.
+
+## Capability object
+
+Minimum fields:
+
+- `capability_id`
+- `node_id`
+- `provider`
+- `execution_class`
+- `runtime`
+- `hardware_family`
+- `locality`
+- `status`
+- `supported_datatypes`
+- `supported_operations`
+- `trust.attestation_required`
+- `warden.required`
+- `evidence.mode`
+- `version`
+
+## Apple MPP provider profile
+
+Provider id: `apple-mpp-local`
+
+Initial status on `ALPHA-NODE-001`: `UNAVAILABLE_UNTIL_RUNNER_ENROLLED`
+
+Required native conditions:
+
+- Apple silicon host running macOS
+- Xcode toolchain with Metal 4 support
+- Metal compiler available through `xcrun`
+- supported Apple GPU/Neural Accelerator hardware
+- runner identity enrolled into Alpha
+- Warden compute grant validation active
+
+MPP-specific tuning such as simdgroup/threadgroup tile size, walk order, synchronization interval, and static tensor extents remains provider-local. These are optimization parameters, not governance fields.
+
+## Control-plane configuration
+
+Environment variables:
+
+- `COMPUTE_PLANE_MODE=governed`
+- `COMPUTE_DEFAULT_PROVIDER=none`
+- `COMPUTE_APPLE_MPP_ENABLED=false`
+- `COMPUTE_APPLE_MPP_RUNNER_URL=`
+- `COMPUTE_APPLE_MPP_RUNNER_ID=`
+- `COMPUTE_REQUIRE_WARDEN_GRANT=true`
+- `COMPUTE_EVIDENCE_MODE=envelope`
+
+`COMPUTE_DEFAULT_PROVIDER=none` is deliberate. Alpha must not silently select a compute backend before Warden authorization and capability resolution.
+
+## Activation gate
+
+The Apple MPP backend may move from `UNAVAILABLE_UNTIL_RUNNER_ENROLLED` to `READY` only when all of the following are evidenced:
+
+1. native readiness probe passes on the Apple runner;
+2. runner identity and capability manifest are registered to `ALPHA-NODE-001`;
+3. Warden compute-grant verification succeeds;
+4. a synthetic non-sensitive tensor workload completes;
+5. the result is returned through the governed adapter;
+6. RiverOS records one compute envelope and Registry records the resulting test effect;
+7. no direct provider bypass path exists.
+
+Until then, MPP is configured but not activated.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "test": "vitest",
     "test:bridge": "vitest run api/registry-bridge.test.ts",
     "test:rc1": "vitest run rc1/runtime.test.ts",
+    "test:compute": "vitest run api/compute-plane.test.ts",
+    "probe:apple-mpp": "bash scripts/bootstrap-apple-mpp-runner.sh",
     "debug": "mcp-inspector npm start"
   },
   "type": "module",

--- a/scripts/bootstrap-apple-mpp-runner.sh
+++ b/scripts/bootstrap-apple-mpp-runner.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT_FILE="${1:-./apple-mpp-readiness.json}"
+NODE_ID="${ALPHA_NODE_ID:-ALPHA-NODE-001}"
+RUNNER_ID="${COMPUTE_APPLE_MPP_RUNNER_ID:-UNASSIGNED}"
+
+fail() {
+  local code="$1"
+  local reason="$2"
+  printf '{\n  "ok": false,\n  "node_id": "%s",\n  "runner_id": "%s",\n  "provider": "apple-mpp-local",\n  "status": "NOT_READY",\n  "reason": "%s"\n}\n' "$NODE_ID" "$RUNNER_ID" "$reason" | tee "$OUT_FILE"
+  exit "$code"
+}
+
+[[ "$(uname -s)" == "Darwin" ]] || fail 20 "requires-macos-apple-runner"
+[[ "$(uname -m)" == "arm64" ]] || fail 21 "requires-apple-silicon-arm64"
+
+command -v xcodebuild >/dev/null 2>&1 || fail 22 "xcode-not-installed"
+command -v xcrun >/dev/null 2>&1 || fail 23 "xcrun-not-available"
+
+XCODE_VERSION="$(xcodebuild -version | awk 'NR==1 {print $2}')"
+XCODE_MAJOR="${XCODE_VERSION%%.*}"
+[[ "$XCODE_MAJOR" =~ ^[0-9]+$ ]] || fail 24 "unable-to-read-xcode-version"
+(( XCODE_MAJOR >= 26 )) || fail 25 "xcode-26-or-later-required"
+
+METAL_BIN="$(xcrun -f metal 2>/dev/null || true)"
+[[ -n "$METAL_BIN" && -x "$METAL_BIN" ]] || fail 26 "metal-compiler-not-found"
+
+SDK_PATH="$(xcrun --sdk macosx --show-sdk-path 2>/dev/null || true)"
+[[ -n "$SDK_PATH" && -d "$SDK_PATH" ]] || fail 27 "macos-sdk-not-found"
+
+CHIP="$(system_profiler SPHardwareDataType 2>/dev/null | awk -F': ' '/Chip:/ {print $2; exit}')"
+[[ -n "$CHIP" ]] || fail 28 "unable-to-identify-apple-chip"
+
+case "$CHIP" in
+  *M5*) ;;
+  *) fail 29 "m5-family-runner-required-for-current-alpha-mpp-profile" ;;
+esac
+
+cat >"$OUT_FILE" <<JSON
+{
+  "ok": true,
+  "node_id": "$NODE_ID",
+  "runner_id": "$RUNNER_ID",
+  "provider": "apple-mpp-local",
+  "status": "TOOLCHAIN_READY",
+  "hardware": "$CHIP",
+  "architecture": "$(uname -m)",
+  "xcode_version": "$XCODE_VERSION",
+  "metal_compiler": "$METAL_BIN",
+  "sdk_path": "$SDK_PATH",
+  "activation_allowed": false,
+  "next_gate": "warden-enrolment-and-synthetic-mpp-workload-proof"
+}
+JSON
+
+cat "$OUT_FILE"
+printf '\nApple MPP toolchain readiness passed. Provider remains fail-closed until Warden enrolment and the synthetic MPP workload proof complete.\n'

--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,9 @@
     "api/health.ts": {
       "maxDuration": 10
     },
+    "api/compute-plane.ts": {
+      "maxDuration": 10
+    },
     "api/mcp.ts": {
       "maxDuration": 60
     },
@@ -19,6 +22,10 @@
     {
       "source": "/health",
       "destination": "/api/health"
+    },
+    {
+      "source": "/compute-plane",
+      "destination": "/api/compute-plane"
     },
     {
       "source": "/mcp",


### PR DESCRIPTION
## Scope

ALPHA-RELEASE-003 first slice for `ALPHA-NODE-001` only. No BNR promotion.

## What this configures

- `REG-COMPUTE-001` hardware-neutral Compute Capability Registry contract.
- Fail-closed Compute Plane environment defaults.
- `apple-mpp-local` as an optional Metal 4 / MPP execution backend, disabled until an enrolled Apple-silicon runner is evidenced.
- `/compute-plane` readiness endpoint with no dispatch capability.
- Native macOS/Xcode/Metal readiness probe for the future Apple runner.
- Tests proving no implicit provider, Warden-required defaults, and fail-closed MPP configuration.
- Preserves the newly merged `ALPHA-RC1-PROGRAM-001` scripts and lint scope.

## Deliberate boundary

The Ubuntu Alpha VM remains the governance/control-plane host. MPP is not installed or emulated on Linux. The MPP provider can only move beyond configuration after a supported Apple runner passes toolchain readiness, Warden enrollment, and a synthetic non-sensitive MPP workload proof.

## Activation still blocked on

1. Enroll/connect the Alpha host to SentinelX if remote VM configuration is desired.
2. Provision a supported Apple-silicon macOS runner with Xcode 26+ / Metal 4.
3. Bind the runner to `ALPHA-NODE-001` under Warden.
4. Execute and evidence the synthetic MPP proof before setting the backend active.
