### PR TITLE
feat(alpha): add Warden-gated compute proof and runner enrollment contract

### DIFF
--- a/compute/runtime.test.ts
+++ b/compute/runtime.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ComputeEvidenceJournal,
+  GovernedComputeCoordinator,
+  SyntheticCpuComputeRunner,
+  makeSyntheticComputeGrant,
+  makeSyntheticComputeIntent,
+} from "./runtime.ts";
+
+const FIXED_NOW = Date.parse("2026-08-13T07:00:00.000Z");
+
+describe("ALPHA-NODE-001 governed compute proof", () => {
+  it("executes only after Warden grant, runner enrollment and evidence reservation", () => {
+    const evidence = new ComputeEvidenceJournal();
+    const coordinator = new GovernedComputeCoordinator(evidence, () => FIXED_NOW);
+    const runner = new SyntheticCpuComputeRunner();
+    coordinator.registerRunner(runner);
+
+    const intent = makeSyntheticComputeIntent("COMPUTE-PROOF-ALLOW-001");
+    const grant = makeSyntheticComputeGrant(intent);
+    const result = coordinator.attempt(intent, grant);
+
+    expect(result.status).toBe("VERIFIED");
+    expect(result.realWorldEffectOccurred).toBe(false);
+    expect(result.result?.values).toEqual([19, 22, 43, 50]);
+    expect(result.result?.sha256).toMatch(/^[a-f0-9]{64}$/);
+
+    const journal = evidence.list();
+    expect(journal.map((entry) => entry.stage)).toEqual(["RESERVED", "SEALED"]);
+    expect(journal[0]?.wardenGrantRef).toBe(grant.grantRef);
+    expect(journal[1]?.resultHash).toBe(result.result?.sha256);
+  });
+
+  it("blocks execution when the Warden compute grant is missing", () => {
+    const evidence = new ComputeEvidenceJournal();
+    const coordinator = new GovernedComputeCoordinator(evidence, () => FIXED_NOW);
+    coordinator.registerRunner(new SyntheticCpuComputeRunner());
+
+    const intent = makeSyntheticComputeIntent("COMPUTE-PROOF-NO-GRANT-001");
+    const result = coordinator.attempt(intent);
+
+    expect(result.status).toBe("BLOCKED_REQUIREMENT");
+    expect(result.reason).toBe("warden_compute_grant_missing");
+    expect(result.result).toBeUndefined();
+    expect(evidence.list()).toHaveLength(1);
+    expect(evidence.list()[0]?.stage).toBe("DENIED");
+  });
+
+  it("denies a provider substitution not explicitly covered by the grant", () => {
+    const evidence = new ComputeEvidenceJournal();
+    const coordinator = new GovernedComputeCoordinator(evidence, () => FIXED_NOW);
+    coordinator.registerRunner(new SyntheticCpuComputeRunner());
+
+    const intent = makeSyntheticComputeIntent("COMPUTE-PROOF-PROVIDER-001");
+    const grant = makeSyntheticComputeGrant(intent);
+    const substitutedIntent = { ...intent, provider: "apple-mpp-local" as const };
+
+    const result = coordinator.attempt(substitutedIntent, grant);
+
+    expect(result.status).toBe("DENIED");
+    expect(result.reason).toBe("grant_provider_mismatch");
+    expect(result.result).toBeUndefined();
+  });
+
+  it("does not treat an Apple MPP capability declaration as an executable runner", () => {
+    const evidence = new ComputeEvidenceJournal();
+    const coordinator = new GovernedComputeCoordinator(evidence, () => FIXED_NOW);
+
+    const base = makeSyntheticComputeIntent("COMPUTE-PROOF-MPP-NOT-ENROLLED-001");
+    const intent = {
+      ...base,
+      provider: "apple-mpp-local" as const,
+      runnerId: "GENESIS-APPLE-RUNNER-001",
+    };
+    const grant = makeSyntheticComputeGrant(intent);
+
+    const result = coordinator.attempt(intent, grant);
+
+    expect(result.status).toBe("UNAVAILABLE");
+    expect(result.reason).toBe("runner_not_registered");
+    expect(result.result).toBeUndefined();
+  });
+
+  it("rejects expired compute grants before evidence reservation or execution", () => {
+    const evidence = new ComputeEvidenceJournal();
+    const coordinator = new GovernedComputeCoordinator(evidence, () => FIXED_NOW);
+    coordinator.registerRunner(new SyntheticCpuComputeRunner());
+
+    const intent = makeSyntheticComputeIntent("COMPUTE-PROOF-EXPIRED-001");
+    const grant = {
+      ...makeSyntheticComputeGrant(intent),
+      issuedAt: "2026-08-13T04:00:00.000Z",
+      expiresAt: "2026-08-13T05:00:00.000Z",
+    };
+
+    const result = coordinator.attempt(intent, grant);
+
+    expect(result.status).toBe("DENIED");
+    expect(result.reason).toBe("grant_expired");
+    expect(result.result).toBeUndefined();
+    expect(evidence.list().map((entry) => entry.stage)).toEqual(["DENIED"]);
+  });
+
+  it("denies an intent whose principal differs from the Warden grant", () => {
+    const evidence = new ComputeEvidenceJournal();
+    const coordinator = new GovernedComputeCoordinator(evidence, () => FIXED_NOW);
+    coordinator.registerRunner(new SyntheticCpuComputeRunner());
+
+    const intent = makeSyntheticComputeIntent("COMPUTE-PROOF-PRINCIPAL-001");
+    const grant = makeSyntheticComputeGrant(intent);
+    const changedIntent = { ...intent, principalRef: "DIGITALME-OTHER-001" };
+
+    const result = coordinator.attempt(changedIntent, grant);
+
+    expect(result.status).toBe("DENIED");
+    expect(result.reason).toBe("grant_principal_mismatch");
+  });
+});

--- a/compute/runtime.ts
+++ b/compute/runtime.ts
@@ -1,0 +1,350 @@
+import { createHash } from "node:crypto";
+
+export const ALPHA_COMPUTE_IDENTITIES = {
+  nodeId: "ALPHA-NODE-001",
+  principalRef: "DIGITALME-ALPHA-TEST-001",
+  representedEntityRef: "LAB-COMPANY-001",
+  wardenRef: "WARDEN-ALPHA-RC1-001",
+  modelRef: "MODEL-SYNTHETIC-GEMM-001",
+} as const;
+
+export type ComputeProvider = "synthetic-cpu-proof" | "apple-mpp-local";
+export type ComputeOperation = "gemm";
+export type RunnerStatus = "ENROLLED" | "REVOKED";
+export type ComputeGrantStatus = "ALLOW" | "DENY";
+export type ComputeAttemptStatus =
+  | "VERIFIED"
+  | "DENIED"
+  | "BLOCKED_REQUIREMENT"
+  | "UNAVAILABLE";
+
+export interface ComputeGrant {
+  grantRef: string;
+  wardenRef: string;
+  nodeId: string;
+  principalRef: string;
+  representedEntityRef: string;
+  provider: ComputeProvider;
+  operation: ComputeOperation;
+  modelRef: string;
+  runnerId: string;
+  status: ComputeGrantStatus;
+  issuedAt: string;
+  expiresAt: string;
+  evidenceRequired: true;
+  synthetic: true;
+}
+
+export interface ComputeIntent {
+  correlationId: string;
+  nodeId: string;
+  principalRef: string;
+  representedEntityRef: string;
+  provider: ComputeProvider;
+  operation: ComputeOperation;
+  modelRef: string;
+  runnerId: string;
+  input: GemmInput;
+  synthetic: true;
+}
+
+export interface RunnerRegistration {
+  runnerId: string;
+  nodeId: string;
+  provider: ComputeProvider;
+  status: RunnerStatus;
+  attested: boolean;
+  toolchainStatus: "SYNTHETIC_READY" | "TOOLCHAIN_READY";
+  hardwareClass: string;
+  synthetic: boolean;
+}
+
+export interface GemmInput {
+  m: number;
+  n: number;
+  k: number;
+  a: number[];
+  b: number[];
+}
+
+export interface GemmResult {
+  rows: number;
+  columns: number;
+  values: number[];
+  sha256: string;
+}
+
+export interface ComputeEvidenceEnvelope {
+  evidenceRef: string;
+  correlationId: string;
+  nodeId: string;
+  principalRef: string;
+  representedEntityRef: string;
+  wardenGrantRef: string;
+  provider: ComputeProvider;
+  runnerId: string;
+  modelRef: string;
+  operation: ComputeOperation;
+  stage: "RESERVED" | "SEALED" | "DENIED";
+  resultHash?: string;
+  reason?: string;
+  synthetic: true;
+}
+
+export interface ComputeAttemptResult {
+  status: ComputeAttemptStatus;
+  correlationId: string;
+  grantRef?: string;
+  reservationRef?: string;
+  evidenceRef?: string;
+  result?: GemmResult;
+  reason?: string;
+  realWorldEffectOccurred: false;
+}
+
+export interface ComputeRunner {
+  registration: RunnerRegistration;
+  execute(intent: ComputeIntent): GemmResult;
+}
+
+function validateGemmInput(input: GemmInput): void {
+  if (!Number.isInteger(input.m) || !Number.isInteger(input.n) || !Number.isInteger(input.k)) {
+    throw new Error("gemm_dimensions_must_be_integers");
+  }
+  if (input.m <= 0 || input.n <= 0 || input.k <= 0) {
+    throw new Error("gemm_dimensions_must_be_positive");
+  }
+  if (input.a.length !== input.m * input.k) {
+    throw new Error("gemm_matrix_a_shape_mismatch");
+  }
+  if (input.b.length !== input.k * input.n) {
+    throw new Error("gemm_matrix_b_shape_mismatch");
+  }
+}
+
+function multiplyGemm(input: GemmInput): GemmResult {
+  validateGemmInput(input);
+  const values = Array<number>(input.m * input.n).fill(0);
+
+  for (let row = 0; row < input.m; row += 1) {
+    for (let column = 0; column < input.n; column += 1) {
+      let sum = 0;
+      for (let inner = 0; inner < input.k; inner += 1) {
+        sum += input.a[row * input.k + inner] * input.b[inner * input.n + column];
+      }
+      values[row * input.n + column] = sum;
+    }
+  }
+
+  return {
+    rows: input.m,
+    columns: input.n,
+    values,
+    sha256: createHash("sha256").update(JSON.stringify(values)).digest("hex"),
+  };
+}
+
+export class SyntheticCpuComputeRunner implements ComputeRunner {
+  readonly registration: RunnerRegistration = {
+    runnerId: "ALPHA-SYNTHETIC-COMPUTE-RUNNER-001",
+    nodeId: ALPHA_COMPUTE_IDENTITIES.nodeId,
+    provider: "synthetic-cpu-proof",
+    status: "ENROLLED",
+    attested: true,
+    toolchainStatus: "SYNTHETIC_READY",
+    hardwareClass: "in-memory-test-runner",
+    synthetic: true,
+  };
+
+  execute(intent: ComputeIntent): GemmResult {
+    if (intent.provider !== this.registration.provider) {
+      throw new Error("runner_provider_mismatch");
+    }
+    if (intent.operation !== "gemm") {
+      throw new Error("runner_operation_unsupported");
+    }
+    return multiplyGemm(intent.input);
+  }
+}
+
+export class ComputeEvidenceJournal {
+  private readonly envelopes: ComputeEvidenceEnvelope[] = [];
+
+  reserve(intent: ComputeIntent, grant: ComputeGrant): string {
+    const evidenceRef = `COMPUTE-EVIDENCE-RESERVATION:${intent.correlationId}`;
+    this.envelopes.push({
+      evidenceRef,
+      correlationId: intent.correlationId,
+      nodeId: intent.nodeId,
+      principalRef: intent.principalRef,
+      representedEntityRef: intent.representedEntityRef,
+      wardenGrantRef: grant.grantRef,
+      provider: intent.provider,
+      runnerId: intent.runnerId,
+      modelRef: intent.modelRef,
+      operation: intent.operation,
+      stage: "RESERVED",
+      synthetic: true,
+    });
+    return evidenceRef;
+  }
+
+  seal(intent: ComputeIntent, grant: ComputeGrant, result: GemmResult): string {
+    const evidenceRef = `COMPUTE-EVIDENCE-SEALED:${intent.correlationId}`;
+    this.envelopes.push({
+      evidenceRef,
+      correlationId: intent.correlationId,
+      nodeId: intent.nodeId,
+      principalRef: intent.principalRef,
+      representedEntityRef: intent.representedEntityRef,
+      wardenGrantRef: grant.grantRef,
+      provider: intent.provider,
+      runnerId: intent.runnerId,
+      modelRef: intent.modelRef,
+      operation: intent.operation,
+      stage: "SEALED",
+      resultHash: result.sha256,
+      synthetic: true,
+    });
+    return evidenceRef;
+  }
+
+  deny(intent: ComputeIntent, grant: ComputeGrant | undefined, reason: string): string {
+    const evidenceRef = `COMPUTE-EVIDENCE-DENIED:${intent.correlationId}`;
+    this.envelopes.push({
+      evidenceRef,
+      correlationId: intent.correlationId,
+      nodeId: intent.nodeId,
+      principalRef: intent.principalRef,
+      representedEntityRef: intent.representedEntityRef,
+      wardenGrantRef: grant?.grantRef ?? "MISSING",
+      provider: intent.provider,
+      runnerId: intent.runnerId,
+      modelRef: intent.modelRef,
+      operation: intent.operation,
+      stage: "DENIED",
+      reason,
+      synthetic: true,
+    });
+    return evidenceRef;
+  }
+
+  list(): ComputeEvidenceEnvelope[] {
+    return this.envelopes.map((entry) => ({ ...entry }));
+  }
+}
+
+export class GovernedComputeCoordinator {
+  private readonly runners = new Map<string, ComputeRunner>();
+
+  constructor(
+    private readonly evidence: ComputeEvidenceJournal,
+    private readonly now: () => number = () => Date.now(),
+  ) {}
+
+  registerRunner(runner: ComputeRunner): void {
+    this.runners.set(runner.registration.runnerId, runner);
+  }
+
+  attempt(intent: ComputeIntent, grant?: ComputeGrant): ComputeAttemptResult {
+    const deny = (reason: string, status: ComputeAttemptStatus = "DENIED"): ComputeAttemptResult => {
+      const evidenceRef = this.evidence.deny(intent, grant, reason);
+      return {
+        status,
+        correlationId: intent.correlationId,
+        grantRef: grant?.grantRef,
+        evidenceRef,
+        reason,
+        realWorldEffectOccurred: false,
+      };
+    };
+
+    if (!grant) return deny("warden_compute_grant_missing", "BLOCKED_REQUIREMENT");
+    if (grant.status !== "ALLOW") return deny("warden_compute_grant_denied");
+    if (!grant.evidenceRequired) return deny("evidence_requirement_missing", "BLOCKED_REQUIREMENT");
+    if (grant.nodeId !== intent.nodeId) return deny("grant_node_mismatch");
+    if (grant.principalRef !== intent.principalRef) return deny("grant_principal_mismatch");
+    if (grant.representedEntityRef !== intent.representedEntityRef) {
+      return deny("grant_entity_mismatch");
+    }
+    if (grant.provider !== intent.provider) return deny("grant_provider_mismatch");
+    if (grant.operation !== intent.operation) return deny("grant_operation_mismatch");
+    if (grant.modelRef !== intent.modelRef) return deny("grant_model_mismatch");
+    if (grant.runnerId !== intent.runnerId) return deny("grant_runner_mismatch");
+    if (grant.wardenRef !== ALPHA_COMPUTE_IDENTITIES.wardenRef) return deny("unknown_warden");
+
+    const issuedAt = Date.parse(grant.issuedAt);
+    const expiresAt = Date.parse(grant.expiresAt);
+    if (!Number.isFinite(issuedAt) || !Number.isFinite(expiresAt) || expiresAt <= issuedAt) {
+      return deny("invalid_grant_validity_window");
+    }
+    const now = this.now();
+    if (now < issuedAt) return deny("grant_not_yet_valid");
+    if (now >= expiresAt) return deny("grant_expired");
+
+    const runner = this.runners.get(intent.runnerId);
+    if (!runner) return deny("runner_not_registered", "UNAVAILABLE");
+    const registration = runner.registration;
+    if (registration.status !== "ENROLLED") return deny("runner_revoked", "UNAVAILABLE");
+    if (!registration.attested) return deny("runner_attestation_required", "BLOCKED_REQUIREMENT");
+    if (registration.nodeId !== intent.nodeId) return deny("runner_node_mismatch");
+    if (registration.provider !== intent.provider) return deny("runner_provider_mismatch");
+
+    const reservationRef = this.evidence.reserve(intent, grant);
+    const result = runner.execute(intent);
+    const evidenceRef = this.evidence.seal(intent, grant, result);
+
+    return {
+      status: "VERIFIED",
+      correlationId: intent.correlationId,
+      grantRef: grant.grantRef,
+      reservationRef,
+      evidenceRef,
+      result,
+      realWorldEffectOccurred: false,
+    };
+  }
+}
+
+export function makeSyntheticComputeIntent(correlationId: string): ComputeIntent {
+  return {
+    correlationId,
+    nodeId: ALPHA_COMPUTE_IDENTITIES.nodeId,
+    principalRef: ALPHA_COMPUTE_IDENTITIES.principalRef,
+    representedEntityRef: ALPHA_COMPUTE_IDENTITIES.representedEntityRef,
+    provider: "synthetic-cpu-proof",
+    operation: "gemm",
+    modelRef: ALPHA_COMPUTE_IDENTITIES.modelRef,
+    runnerId: "ALPHA-SYNTHETIC-COMPUTE-RUNNER-001",
+    input: {
+      m: 2,
+      n: 2,
+      k: 2,
+      a: [1, 2, 3, 4],
+      b: [5, 6, 7, 8],
+    },
+    synthetic: true,
+  };
+}
+
+export function makeSyntheticComputeGrant(
+  intent: ComputeIntent,
+  status: ComputeGrantStatus = "ALLOW",
+): ComputeGrant {
+  return {
+    grantRef: `WARDEN-COMPUTE-GRANT:${intent.correlationId}`,
+    wardenRef: ALPHA_COMPUTE_IDENTITIES.wardenRef,
+    nodeId: intent.nodeId,
+    principalRef: intent.principalRef,
+    representedEntityRef: intent.representedEntityRef,
+    provider: intent.provider,
+    operation: intent.operation,
+    modelRef: intent.modelRef,
+    runnerId: intent.runnerId,
+    status,
+    issuedAt: "2026-08-13T06:00:00.000Z",
+    expiresAt: "2026-08-13T08:00:00.000Z",
+    evidenceRequired: true,
+    synthetic: true,
+  };
+}

--- a/config/compute/apple-mpp-runner-registration.example.json
+++ b/config/compute/apple-mpp-runner-registration.example.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "1.0",
+  "registration_type": "compute-runner",
+  "node_id": "ALPHA-NODE-001",
+  "runner_id": "GENESIS-APPLE-RUNNER-001",
+  "provider": "apple-mpp-local",
+  "status": "PENDING_ENROLMENT",
+  "hardware": {
+    "family": "apple-m5",
+    "architecture": "arm64",
+    "device_ref": "REPLACE_WITH_REGISTRY_DEVICE_REF"
+  },
+  "runtime": {
+    "name": "metal4-mpp",
+    "toolchain_status": "PENDING_NATIVE_PROBE",
+    "readiness_evidence_ref": null
+  },
+  "trust": {
+    "attestation_required": true,
+    "attestation_evidence_ref": null
+  },
+  "warden": {
+    "compute_grant_required": true,
+    "direct_dispatch_permitted": false
+  },
+  "evidence": {
+    "reservation_required_before_dispatch": true,
+    "seal_required_after_verification": true,
+    "mode": "envelope"
+  },
+  "fallback": {
+    "implicit_provider_fallback": false
+  },
+  "activation": {
+    "allowed": false,
+    "required_proof": "ALPHA-COMPUTE-MPP-PROOF-001"
+  }
+}

--- a/docs/alpha-node/ALPHA-COMPUTE-PROOF-001.md
+++ b/docs/alpha-node/ALPHA-COMPUTE-PROOF-001.md
@@ -1,0 +1,102 @@
+# ALPHA-COMPUTE-PROOF-001
+
+Status: `SYNTHETIC CONFORMANCE PROOF`
+Scope: `ALPHA-NODE-001`
+Registry object: `REG-COMPUTE-001`
+
+## Purpose
+
+Prove the governance boundary between Warden-authorized cognition and a replaceable execution backend before any native Apple MPP runner is activated.
+
+This proof is intentionally synthetic. It performs a deterministic 2 x 2 GEMM on an in-memory CPU runner and creates no external, legal, financial, participant, or settlement effect.
+
+## Required sequence
+
+`IDENTIFY -> RESOLVE CAPABILITY -> WARDEN COMPUTE GRANT -> VERIFY RUNNER -> RESERVE EVIDENCE -> EXECUTE -> VERIFY RESULT -> SEAL EVIDENCE -> RETURN RESULT`
+
+Execution is forbidden when any of the following is absent or mismatched:
+
+- Warden grant
+- principal
+- represented entity
+- node
+- provider
+- operation
+- model
+- runner
+- validity window
+- evidence requirement
+- enrolled + attested runner
+
+## Why the first proof uses a synthetic CPU runner
+
+The Ubuntu Alpha control host cannot execute Apple Metal Performance Primitives. The synthetic runner proves the control path without pretending to prove Metal or MPP hardware execution.
+
+The Apple provider therefore remains:
+
+`apple-mpp-local = UNAVAILABLE_UNTIL_RUNNER_ENROLLED`
+
+A declaration in `REG-COMPUTE-001` is capability metadata only. It does not create an executable provider.
+
+## Synthetic workload
+
+Input:
+
+```text
+A = [1 2]      B = [5 6]
+    [3 4]          [7 8]
+```
+
+Expected output:
+
+```text
+D = [19 22]
+    [43 50]
+```
+
+The proof hashes the deterministic result and places only the governed execution envelope and result hash into the evidence journal.
+
+## Evidence envelope
+
+Minimum fields:
+
+- evidence reference
+- correlation id
+- `ALPHA-NODE-001`
+- DigitalMe principal reference
+- represented entity reference
+- Warden compute-grant reference
+- provider
+- runner
+- model
+- operation
+- stage: `RESERVED | SEALED | DENIED`
+- result hash when sealed
+- reason when denied
+
+Raw low-level tensor operations are not evidence objects.
+
+## Promotion conditions for Apple MPP
+
+The MPP backend may not be marked `READY` from configuration alone. A later native proof must establish:
+
+1. supported Apple-silicon runner;
+2. Metal 4 / MPP-capable toolchain readiness;
+3. runner enrollment to `ALPHA-NODE-001`;
+4. attestation evidence;
+5. Warden compute grant scoped to `apple-mpp-local` and the runner id;
+6. evidence reservation before dispatch;
+7. successful non-sensitive native tensor workload;
+8. result verification and evidence sealing;
+9. no implicit provider fallback;
+10. no direct MPP bypass around Warden.
+
+## Relationship to ALPHA-RC1-PROGRAM-001
+
+RC1 proves the broader `Registry -> Warden -> Synnergyze -> Action Gateway -> River -> Registry Effect` operating slice.
+
+ALPHA-COMPUTE-PROOF-001 proves the narrower cognition/compute boundary beneath that operating slice:
+
+`Warden -> Compute Grant -> Compute Plane -> Runner -> Result -> Evidence`.
+
+The two proofs are complementary and neither is a production authority implementation.

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "scripts": {
     "start": "node --experimental-strip-types --no-warnings=ExperimentalWarnings src/app.ts",
     "type-check": "tsc --noEmit",
-    "lint": "eslint --ext .ts src api rc1",
+    "lint": "eslint --ext .ts src api rc1 compute",
     "test": "vitest",
     "test:bridge": "vitest run api/registry-bridge.test.ts",
     "test:rc1": "vitest run rc1/runtime.test.ts",
-    "test:compute": "vitest run api/compute-plane.test.ts",
+    "test:compute": "vitest run api/compute-plane.test.ts compute/runtime.test.ts",
+    "test:compute-proof": "vitest run compute/runtime.test.ts",
     "probe:apple-mpp": "bash scripts/bootstrap-apple-mpp-runner.sh",
     "debug": "mcp-inspector npm start"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
     "noUnusedLocals": true,
     "resolveJsonModule": true
   },
-  "include": ["api/**/*.ts", "rc1/**/*.ts"],
+  "include": ["api/**/*.ts", "rc1/**/*.ts", "compute/**/*.ts"],
   "exclude": ["src/**", "node_modules"]
 }


### PR DESCRIPTION
## Scope

Second Compute Plane slice for `ALPHA-NODE-001`.

## Adds

- `compute/runtime.ts`: Warden compute-grant contract, runner enrollment checks, evidence reservation/sealing, provider/runner/model/principal binding and deterministic synthetic GEMM proof.
- `compute/runtime.test.ts`: allow path plus missing-grant, provider-substitution, unregistered-MPP, expired-grant and principal-mismatch denial cases.
- `ALPHA-COMPUTE-PROOF-001`: evidence and promotion boundary.
- Apple MPP runner registration template with activation disabled until native proof.
- `test:compute-proof` and compute type-check/lint coverage.

## Boundary

This does **not** execute Metal or MPP and does not claim hardware proof. The only executable test runner is an in-memory synthetic CPU runner used to prove `Warden -> Compute Grant -> Evidence Reservation -> Runner -> Result -> Evidence Seal` semantics. `apple-mpp-local` remains unavailable until an enrolled Apple-silicon runner passes the native proof.
