### PR TITLE
feat(alpha): add native Apple MPP compile gate

### DIFF
--- a/native/apple-mpp/AlphaMppGemmProbe.metal
+++ b/native/apple-mpp/AlphaMppGemmProbe.metal
@@ -1,0 +1,36 @@
+#include <metal_stdlib>
+#include <metal_tensor>
+#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+
+using namespace metal;
+using namespace mpp;
+
+constant int kAlphaProbeTile = 64;
+
+kernel void alpha_mpp_gemm_probe(
+    uint2 groupId [[threadgroup_position_in_grid]],
+    tensor<device half, dextents<int, 2>> lhs,
+    tensor<device half, dextents<int, 2>> rhs,
+    tensor<device half, dextents<int, 2>> output)
+{
+    const int originX = kAlphaProbeTile * int(groupId.x);
+    const int originY = kAlphaProbeTile * int(groupId.y);
+
+    auto lhsTile = lhs.slice<dynamic_extent, kAlphaProbeTile>(0, originY);
+    auto rhsTile = rhs.slice<kAlphaProbeTile, dynamic_extent>(originX, 0);
+    auto outputTile = output.slice<kAlphaProbeTile, kAlphaProbeTile>(originX, originY);
+
+    constexpr auto descriptor = tensor_ops::matmul2d_descriptor(
+        kAlphaProbeTile,
+        kAlphaProbeTile,
+        dynamic_length_v<int>);
+
+    tensor_ops::matmul2d<descriptor, execution_simdgroups<4>> operation;
+    auto localResult = operation.get_destination_cooperative_tensor<
+        decltype(lhsTile),
+        decltype(rhsTile),
+        half>();
+
+    operation.run(lhsTile, rhsTile, localResult);
+    localResult.store(outputTile);
+}

--- a/native/apple-mpp/README.md
+++ b/native/apple-mpp/README.md
@@ -1,0 +1,54 @@
+# Apple MPP native compile gate
+
+This directory prepares the first native Apple Metal Performance Primitives compile proof for `ALPHA-NODE-001`.
+
+## What this proves
+
+`npm run compile:apple-mpp` is intended to run only on an enrolled Apple-silicon macOS runner. It:
+
+1. verifies macOS + arm64;
+2. resolves the active Xcode Metal compiler with `xcrun`;
+3. compiles `AlphaMppGemmProbe.metal` to Metal IR;
+4. links the IR into a `.metallib`;
+5. hashes the source and compiled library;
+6. emits `compile-evidence.json` with `activation_allowed: false`.
+
+A successful compile proves only that the selected native toolchain accepts the probe source. It does **not** prove GPU dispatch, Neural Accelerator execution, result correctness, runner attestation, Warden authorization, or RiverOS evidence sealing.
+
+## Probe kernel
+
+The kernel uses Metal tensor parameters and the MPP tensor-ops matrix multiplication API. It tiles the output in 64 x 64 blocks, uses four SIMD groups for each threadgroup-scoped operation, accumulates into a cooperative tensor, and stores the result to the output tensor.
+
+The implementation follows the architecture described by Apple's MPP Programming Guide and Apple's `Running inline ML operations in a shader with Metal 4` sample, while remaining an Alpha-owned probe rather than a vendored copy of Apple's sample project.
+
+## Run sequence
+
+On the future enrolled runner:
+
+```bash
+export ALPHA_NODE_ID=ALPHA-NODE-001
+export COMPUTE_APPLE_MPP_RUNNER_ID=GENESIS-APPLE-RUNNER-001
+npm run probe:apple-mpp
+npm run compile:apple-mpp
+```
+
+Expected artifact directory:
+
+```text
+.alpha/mpp-build/
+  AlphaMppGemmProbe.ir
+  AlphaMppGemmProbe.metallib
+  compile-evidence.json
+```
+
+The `.alpha/` directory is local proof output and must not become Registry truth by itself. Its evidence is promotable only after Warden/Registry ingestion under the compute-proof workflow.
+
+## Next gate
+
+`ALPHA-COMPUTE-MPP-PROOF-001` must add an actual host-side Metal dispatch that:
+
+- creates/binds tensors;
+- dispatches the native kernel;
+- verifies a known GEMM result against a CPU reference;
+- seals the governed compute evidence envelope;
+- keeps `apple-mpp-local` disabled on any failure.

--- a/native/apple-mpp/build-probe.sh
+++ b/native/apple-mpp/build-probe.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SRC="$ROOT_DIR/native/apple-mpp/AlphaMppGemmProbe.metal"
+OUT_DIR="${ALPHA_MPP_BUILD_DIR:-$ROOT_DIR/.alpha/mpp-build}"
+IR="$OUT_DIR/AlphaMppGemmProbe.ir"
+LIB="$OUT_DIR/AlphaMppGemmProbe.metallib"
+EVIDENCE="$OUT_DIR/compile-evidence.json"
+NODE_ID="${ALPHA_NODE_ID:-ALPHA-NODE-001}"
+RUNNER_ID="${COMPUTE_APPLE_MPP_RUNNER_ID:-UNASSIGNED}"
+
+mkdir -p "$OUT_DIR"
+
+fail() {
+  local code="$1"
+  local reason="$2"
+  printf '{\n  "ok": false,\n  "node_id": "%s",\n  "runner_id": "%s",\n  "provider": "apple-mpp-local",\n  "proof_stage": "COMPILE",\n  "reason": "%s",\n  "activation_allowed": false\n}\n' \
+    "$NODE_ID" "$RUNNER_ID" "$reason" | tee "$EVIDENCE"
+  exit "$code"
+}
+
+[[ "$(uname -s)" == "Darwin" ]] || fail 40 "requires-macos"
+[[ "$(uname -m)" == "arm64" ]] || fail 41 "requires-apple-silicon-arm64"
+command -v xcrun >/dev/null 2>&1 || fail 42 "xcrun-not-found"
+command -v xcodebuild >/dev/null 2>&1 || fail 43 "xcodebuild-not-found"
+[[ -f "$SRC" ]] || fail 44 "probe-source-missing"
+
+METAL_BIN="$(xcrun -sdk macosx -f metal 2>/dev/null || true)"
+[[ -n "$METAL_BIN" ]] || fail 45 "metal-compiler-not-found"
+
+XCODE_VERSION="$(xcodebuild -version | awk 'NR==1 {print $2}')"
+CHIP="$(system_profiler SPHardwareDataType 2>/dev/null | awk -F': ' '/Chip:/ {print $2; exit}')"
+[[ -n "$CHIP" ]] || fail 46 "apple-chip-undetected"
+
+rm -f "$IR" "$LIB"
+xcrun -sdk macosx metal -c "$SRC" -o "$IR"
+xcrun -sdk macosx metal "$IR" -o "$LIB"
+
+[[ -s "$IR" ]] || fail 47 "metal-ir-not-produced"
+[[ -s "$LIB" ]] || fail 48 "metallib-not-produced"
+
+SOURCE_SHA="$(shasum -a 256 "$SRC" | awk '{print $1}')"
+LIB_SHA="$(shasum -a 256 "$LIB" | awk '{print $1}')"
+
+cat >"$EVIDENCE" <<JSON
+{
+  "ok": true,
+  "node_id": "$NODE_ID",
+  "runner_id": "$RUNNER_ID",
+  "provider": "apple-mpp-local",
+  "proof_stage": "COMPILE",
+  "hardware": "$CHIP",
+  "architecture": "$(uname -m)",
+  "xcode_version": "$XCODE_VERSION",
+  "metal_compiler": "$METAL_BIN",
+  "source_sha256": "$SOURCE_SHA",
+  "metallib_sha256": "$LIB_SHA",
+  "metallib": "$LIB",
+  "activation_allowed": false,
+  "next_gate": "native-dispatch-and-result-verification"
+}
+JSON
+
+cat "$EVIDENCE"
+printf '\nCompile gate passed. This is not an MPP execution proof and does not activate the provider.\n'

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:compute": "vitest run api/compute-plane.test.ts compute/runtime.test.ts",
     "test:compute-proof": "vitest run compute/runtime.test.ts",
     "probe:apple-mpp": "bash scripts/bootstrap-apple-mpp-runner.sh",
+    "compile:apple-mpp": "bash native/apple-mpp/build-probe.sh",
     "debug": "mcp-inspector npm start"
   },
   "type": "module",


### PR DESCRIPTION
## Scope

Native compile preparation for the `apple-mpp-local` backend under `ALPHA-NODE-001`.

## Adds

- `native/apple-mpp/AlphaMppGemmProbe.metal`: Alpha-owned MPP tensor GEMM probe using Metal tensor parameters, 64x64 tiling, four SIMD groups and a cooperative tensor result.
- `native/apple-mpp/build-probe.sh`: macOS/arm64/Xcode/Metal compile gate that produces Metal IR, a `.metallib`, hashes both source and library, and emits fail-closed compile evidence.
- `npm run compile:apple-mpp`.
- Native probe documentation and the next execution-proof boundary.

## Boundary

This PR is **compile-only**. It does not dispatch the kernel and must not activate `apple-mpp-local`. A successful native compile records `activation_allowed: false`; the next gate remains host-side tensor binding, dispatch, result verification, Warden grant enforcement and evidence sealing on an enrolled Apple-silicon runner.
