### PR TITLE
AF-002/AF-003: Warden-issued Agent identity and model binding

### DIFF
--- a/agent-fabric/authority-boundary.test.ts
+++ b/agent-fabric/authority-boundary.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AGENT_RC1_IDENTITIES,
+  AgentRuntime,
+  DeterministicModelAdapter,
+  SyntheticWardenAgentAuthority,
+} from "./runtime.js";
+
+const ISSUED_AT = "2026-08-13T07:10:00.000Z";
+const SWAP_AT = "2026-08-13T07:11:00.000Z";
+
+const modelA = new DeterministicModelAdapter({
+  adapterRef: "MODEL-ADAPTER-A-001",
+  providerRef: "SYNTHETIC-PROVIDER-A",
+  modelRef: "SYNTHETIC-MODEL-A",
+});
+const modelB = new DeterministicModelAdapter({
+  adapterRef: "MODEL-ADAPTER-B-001",
+  providerRef: "SYNTHETIC-PROVIDER-B",
+  modelRef: "SYNTHETIC-MODEL-B",
+});
+
+describe("AF-002 / AF-003 authority non-expansion", () => {
+  it("never grants a policy capability that the requester did not request", () => {
+    const warden = new SyntheticWardenAgentAuthority();
+    const result = warden.issue({
+      requesterRef: AGENT_RC1_IDENTITIES.requesterRef,
+      representedEntityRef: AGENT_RC1_IDENTITIES.representedEntityRef,
+      packRef: AGENT_RC1_IDENTITIES.packRef,
+      requestedAgentId: AGENT_RC1_IDENTITIES.agentId,
+      requestedIssuanceId: AGENT_RC1_IDENTITIES.issuanceId,
+      requestedCapabilities: ["entity.profile.read"],
+      requestedAt: ISSUED_AT,
+    });
+
+    expect(result.decision).toBe("ALLOW");
+    expect(result.envelope?.allowedCapabilities).toEqual(["entity.profile.read"]);
+    expect(result.envelope?.allowedCapabilities).not.toContain("service_request.create");
+    expect(result.envelope?.deniedCapabilities).toContain("contract.execute");
+  });
+
+  it("denies issuance when Registry-resolved synthetic identity references do not match", () => {
+    const warden = new SyntheticWardenAgentAuthority();
+    const result = warden.issue({
+      requesterRef: "DIGITALME-IMPOSTOR-001",
+      representedEntityRef: AGENT_RC1_IDENTITIES.representedEntityRef,
+      packRef: AGENT_RC1_IDENTITIES.packRef,
+      requestedAgentId: AGENT_RC1_IDENTITIES.agentId,
+      requestedIssuanceId: AGENT_RC1_IDENTITIES.issuanceId,
+      requestedCapabilities: ["entity.profile.read"],
+      requestedAt: ISSUED_AT,
+    });
+
+    expect(result.decision).toBe("DENY");
+    expect(result.reason).toBe("registry_identity_resolution_mismatch");
+    expect(result.envelope).toBeUndefined();
+  });
+
+  it("rejects a model binding profile that expands beyond the Warden issuance envelope", () => {
+    const warden = new SyntheticWardenAgentAuthority();
+    const issuance = warden.issue({
+      requesterRef: AGENT_RC1_IDENTITIES.requesterRef,
+      representedEntityRef: AGENT_RC1_IDENTITIES.representedEntityRef,
+      packRef: AGENT_RC1_IDENTITIES.packRef,
+      requestedAgentId: AGENT_RC1_IDENTITIES.agentId,
+      requestedIssuanceId: AGENT_RC1_IDENTITIES.issuanceId,
+      requestedCapabilities: ["entity.profile.read", "service_request.create"],
+      requestedAt: ISSUED_AT,
+    }).envelope;
+    if (!issuance) throw new Error("test_issuance_missing");
+
+    const initialDecision = warden.authorizeBindingChange(
+      issuance,
+      modelA.adapterRef,
+      "WARDEN-MODEL-BINDING-A-AUTHORITY-TEST",
+    );
+    const runtime = AgentRuntime.activate({
+      issuance,
+      initialBindingRef: AGENT_RC1_IDENTITIES.modelABindingRef,
+      initialBindingDecision: initialDecision,
+      adapterRegistry: [modelA, modelB],
+      purpose: "company-base-agent",
+      capabilityProfile: issuance.allowedCapabilities,
+      activatedAt: ISSUED_AT,
+      idempotencyKey: "AGENT-BIND-A-AUTHORITY-TEST",
+    });
+    const before = runtime.activeBinding();
+    const nextDecision = warden.authorizeBindingChange(
+      issuance,
+      modelB.adapterRef,
+      "WARDEN-MODEL-BINDING-B-AUTHORITY-TEST",
+    );
+
+    expect(() =>
+      runtime.swapModel({
+        bindingRef: AGENT_RC1_IDENTITIES.modelBBindingRef,
+        bindingDecision: nextDecision,
+        identityGuard: runtime.identityGuard(),
+        purpose: "company-base-agent",
+        capabilityProfile: [...issuance.allowedCapabilities, "contract.execute"],
+        activatedAt: SWAP_AT,
+        idempotencyKey: "AGENT-SWAP-A-B-AUTHORITY-TEST",
+      }),
+    ).toThrow("model_binding_capability_expansion");
+    expect(runtime.activeBinding()).toEqual(before);
+    expect(runtime.bindingHistory()).toHaveLength(1);
+  });
+});

--- a/agent-fabric/runtime.test.ts
+++ b/agent-fabric/runtime.test.ts
@@ -1,0 +1,306 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  AGENT_RC1_IDENTITIES,
+  AgentRuntime,
+  DeterministicModelAdapter,
+  SyntheticWardenAgentAuthority,
+} from "./runtime.js";
+import type { WardenAuthorityEnvelope } from "./runtime.js";
+
+const ISSUED_AT = "2026-08-13T07:10:00.000Z";
+const SWAP_AT = "2026-08-13T07:11:00.000Z";
+const REVOKED_AT = "2026-08-13T07:12:00.000Z";
+
+const modelA = new DeterministicModelAdapter({
+  adapterRef: "MODEL-ADAPTER-A-001",
+  providerRef: "SYNTHETIC-PROVIDER-A",
+  modelRef: "SYNTHETIC-MODEL-A",
+});
+const modelB = new DeterministicModelAdapter({
+  adapterRef: "MODEL-ADAPTER-B-001",
+  providerRef: "SYNTHETIC-PROVIDER-B",
+  modelRef: "SYNTHETIC-MODEL-B",
+});
+const unapprovedModel = new DeterministicModelAdapter({
+  adapterRef: "MODEL-ADAPTER-UNAPPROVED-001",
+  providerRef: "SYNTHETIC-PROVIDER-X",
+  modelRef: "SYNTHETIC-MODEL-X",
+});
+
+function issueEnvelope(
+  warden = new SyntheticWardenAgentAuthority(),
+): { warden: SyntheticWardenAgentAuthority; envelope: WardenAuthorityEnvelope } {
+  const result = warden.issue({
+    requesterRef: AGENT_RC1_IDENTITIES.requesterRef,
+    representedEntityRef: AGENT_RC1_IDENTITIES.representedEntityRef,
+    packRef: AGENT_RC1_IDENTITIES.packRef,
+    requestedAgentId: AGENT_RC1_IDENTITIES.agentId,
+    requestedIssuanceId: AGENT_RC1_IDENTITIES.issuanceId,
+    requestedCapabilities: ["entity.profile.read", "service_request.create"],
+    requestedAt: ISSUED_AT,
+  });
+  if (!result.envelope) {
+    throw new Error(`test_issuance_failed:${result.decision}:${result.reason}`);
+  }
+  return { warden, envelope: result.envelope };
+}
+
+function activateRuntime(): {
+  warden: SyntheticWardenAgentAuthority;
+  envelope: WardenAuthorityEnvelope;
+  runtime: AgentRuntime;
+} {
+  const { warden, envelope } = issueEnvelope();
+  const decision = warden.authorizeBindingChange(
+    envelope,
+    modelA.adapterRef,
+    "WARDEN-MODEL-BINDING-A-001",
+  );
+  const runtime = AgentRuntime.activate({
+    issuance: envelope,
+    initialBindingRef: AGENT_RC1_IDENTITIES.modelABindingRef,
+    initialBindingDecision: decision,
+    adapterRegistry: [modelA, modelB, unapprovedModel],
+    purpose: "company-base-agent",
+    capabilityProfile: envelope.allowedCapabilities,
+    activatedAt: ISSUED_AT,
+    idempotencyKey: "AGENT-BIND-A-001",
+  });
+  return { warden, envelope, runtime };
+}
+
+function swapToModelB(
+  warden: SyntheticWardenAgentAuthority,
+  envelope: WardenAuthorityEnvelope,
+  runtime: AgentRuntime,
+) {
+  const decision = warden.authorizeBindingChange(
+    envelope,
+    modelB.adapterRef,
+    "WARDEN-MODEL-BINDING-B-001",
+  );
+  return runtime.swapModel({
+    bindingRef: AGENT_RC1_IDENTITIES.modelBBindingRef,
+    bindingDecision: decision,
+    identityGuard: runtime.identityGuard(),
+    purpose: "company-base-agent",
+    capabilityProfile: envelope.allowedCapabilities,
+    activatedAt: SWAP_AT,
+    idempotencyKey: "AGENT-SWAP-A-B-001",
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AF-002 / AF-003 Warden-issued Agent runtime", () => {
+  it("keeps Agent identity, issuance, authority and session continuity across Model A to Model B", () => {
+    const { warden, envelope, runtime } = activateRuntime();
+    const authorityBefore = runtime.authorityEnvelope();
+    const sessionBefore = runtime.openSession({ sessionId: "AGENT-SESSION-001", openedAt: ISSUED_AT });
+
+    const proposalA = runtime.invoke({
+      sessionId: sessionBefore.sessionId,
+      prompt: "read the approved company profile",
+      requestedCapability: "entity.profile.read",
+    });
+    expect(proposalA.modelRef).toBe(modelA.modelRef);
+    expect(proposalA.authorized).toBe(false);
+
+    const bindingB = swapToModelB(warden, envelope, runtime);
+    const proposalB = runtime.invoke({
+      sessionId: sessionBefore.sessionId,
+      prompt: "continue the same governed session",
+      requestedCapability: "entity.profile.read",
+    });
+    const sessionAfter = runtime.session(sessionBefore.sessionId);
+    const authorityAfter = runtime.authorityEnvelope();
+
+    expect(bindingB.agentId).toBe(AGENT_RC1_IDENTITIES.agentId);
+    expect(bindingB.issuanceId).toBe(AGENT_RC1_IDENTITIES.issuanceId);
+    expect(bindingB.authorityFingerprint).toBe(envelope.authorityFingerprint);
+    expect(proposalB.modelRef).toBe(modelB.modelRef);
+    expect(proposalB.agentId).toBe(proposalA.agentId);
+    expect(proposalB.issuanceId).toBe(proposalA.issuanceId);
+    expect(sessionAfter.continuityRef).toBe(sessionBefore.continuityRef);
+    expect(sessionAfter.invocationSequence).toBe(2);
+    expect(authorityAfter).toEqual(authorityBefore);
+
+    const history = runtime.bindingHistory();
+    expect(history).toHaveLength(2);
+    expect(history[0].lifecycleState).toBe("SUPERSEDED");
+    expect(history[1].lifecycleState).toBe("ACTIVE");
+    expect(history[1].predecessorBindingRef).toBe(history[0].bindingRef);
+  });
+
+  it("fails closed when no Warden issuance exists", () => {
+    const decision = new SyntheticWardenAgentAuthority().authorizeBindingChange(
+      issueEnvelope().envelope,
+      modelA.adapterRef,
+      "WARDEN-MODEL-BINDING-MISSING-ISSUANCE",
+    );
+
+    expect(() =>
+      AgentRuntime.activate({
+        issuance: undefined,
+        initialBindingRef: AGENT_RC1_IDENTITIES.modelABindingRef,
+        initialBindingDecision: decision,
+        adapterRegistry: [modelA],
+        purpose: "company-base-agent",
+        capabilityProfile: ["entity.profile.read"],
+        activatedAt: ISSUED_AT,
+        idempotencyKey: "MISSING-ISSUANCE",
+      }),
+    ).toThrow("warden_issuance_required");
+  });
+
+  it("does not create an active Agent for DENY or ESCALATE issuance decisions", () => {
+    for (const issuanceDecision of ["DENY", "ESCALATE"] as const) {
+      const warden = new SyntheticWardenAgentAuthority({ issuanceDecision });
+      const result = warden.issue({
+        requesterRef: AGENT_RC1_IDENTITIES.requesterRef,
+        representedEntityRef: AGENT_RC1_IDENTITIES.representedEntityRef,
+        packRef: AGENT_RC1_IDENTITIES.packRef,
+        requestedAgentId: AGENT_RC1_IDENTITIES.agentId,
+        requestedIssuanceId: AGENT_RC1_IDENTITIES.issuanceId,
+        requestedCapabilities: ["entity.profile.read"],
+        requestedAt: ISSUED_AT,
+      });
+
+      expect(result.decision).toBe(issuanceDecision);
+      expect(result.envelope).toBeUndefined();
+    }
+  });
+
+  it("rejects an unapproved model adapter without changing the active binding", () => {
+    const { warden, envelope, runtime } = activateRuntime();
+    const before = runtime.activeBinding();
+    const deniedDecision = warden.authorizeBindingChange(
+      envelope,
+      unapprovedModel.adapterRef,
+      "WARDEN-MODEL-BINDING-X-DENY",
+    );
+
+    expect(deniedDecision.decision).toBe("DENY");
+    expect(() =>
+      runtime.swapModel({
+        bindingRef: "MODEL-BINDING-X-001",
+        bindingDecision: deniedDecision,
+        identityGuard: runtime.identityGuard(),
+        purpose: "company-base-agent",
+        capabilityProfile: envelope.allowedCapabilities,
+        activatedAt: SWAP_AT,
+        idempotencyKey: "AGENT-SWAP-A-X-001",
+      }),
+    ).toThrow("warden_model_binding_denied");
+    expect(runtime.activeBinding()).toEqual(before);
+    expect(runtime.bindingHistory()).toHaveLength(1);
+  });
+
+  it("rejects a model swap that attempts Agent, issuance, entity or authority drift", () => {
+    const { warden, envelope, runtime } = activateRuntime();
+    const decision = warden.authorizeBindingChange(
+      envelope,
+      modelB.adapterRef,
+      "WARDEN-MODEL-BINDING-B-DRIFT",
+    );
+
+    expect(() =>
+      runtime.swapModel({
+        bindingRef: AGENT_RC1_IDENTITIES.modelBBindingRef,
+        bindingDecision: decision,
+        identityGuard: { ...runtime.identityGuard(), agentId: "AGENT-IMPOSTOR-001" },
+        purpose: "company-base-agent",
+        capabilityProfile: envelope.allowedCapabilities,
+        activatedAt: SWAP_AT,
+        idempotencyKey: "AGENT-SWAP-DRIFT-001",
+      }),
+    ).toThrow("model_swap_identity_or_authority_drift");
+    expect(runtime.activeBinding().modelRef).toBe(modelA.modelRef);
+  });
+
+  it("makes duplicate model-swap idempotency keys replay the same binding exactly once", () => {
+    const { warden, envelope, runtime } = activateRuntime();
+    const decision = warden.authorizeBindingChange(
+      envelope,
+      modelB.adapterRef,
+      "WARDEN-MODEL-BINDING-B-IDEMPOTENT",
+    );
+    const request = {
+      bindingRef: AGENT_RC1_IDENTITIES.modelBBindingRef,
+      bindingDecision: decision,
+      identityGuard: runtime.identityGuard(),
+      purpose: "company-base-agent",
+      capabilityProfile: envelope.allowedCapabilities,
+      activatedAt: SWAP_AT,
+      idempotencyKey: "AGENT-SWAP-IDEMPOTENT-001",
+    };
+
+    const first = runtime.swapModel(request);
+    const second = runtime.swapModel(request);
+
+    expect(second).toEqual(first);
+    expect(runtime.bindingHistory()).toHaveLength(2);
+  });
+
+  it("keeps model output proposal-only for allowed and forbidden controlled capabilities", () => {
+    const { runtime } = activateRuntime();
+    runtime.openSession({ sessionId: "AGENT-SESSION-PROPOSAL-001", openedAt: ISSUED_AT });
+
+    for (const requestedCapability of ["service_request.create", "contract.execute"]) {
+      const proposal = runtime.invoke({
+        sessionId: "AGENT-SESSION-PROPOSAL-001",
+        prompt: `propose ${requestedCapability}`,
+        requestedCapability,
+      });
+      expect(proposal.requiresWardenDecision).toBe(true);
+      expect(proposal.authorized).toBe(false);
+      expect(proposal.actionToken).toBeUndefined();
+    }
+  });
+
+  it("stops model invocation after a matching Warden revocation", () => {
+    const { warden, envelope, runtime } = activateRuntime();
+    runtime.openSession({ sessionId: "AGENT-SESSION-REVOKE-001", openedAt: ISSUED_AT });
+    const revocation = warden.revoke(envelope, {
+      decisionRef: "WARDEN-AGENT-REVOCATION-001",
+      revokedAt: REVOKED_AT,
+      reason: "synthetic_conformance_revocation",
+    });
+
+    runtime.applyRevocation(revocation);
+
+    expect(runtime.state()).toBe("REVOKED");
+    expect(runtime.revocationDecision()?.decisionRef).toBe(revocation.decisionRef);
+    expect(() =>
+      runtime.invoke({
+        sessionId: "AGENT-SESSION-REVOKE-001",
+        prompt: "continue after revocation",
+        requestedCapability: "entity.profile.read",
+      }),
+    ).toThrow("agent_issuance_revoked");
+  });
+
+  it("performs the issuance, binding and swap conformance path without external network calls", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      throw new Error("external_network_forbidden_in_agent_conformance");
+    });
+    const { warden, envelope, runtime } = activateRuntime();
+    runtime.openSession({ sessionId: "AGENT-SESSION-NETWORK-001", openedAt: ISSUED_AT });
+    runtime.invoke({
+      sessionId: "AGENT-SESSION-NETWORK-001",
+      prompt: "model A proposal",
+      requestedCapability: "entity.profile.read",
+    });
+    swapToModelB(warden, envelope, runtime);
+    runtime.invoke({
+      sessionId: "AGENT-SESSION-NETWORK-001",
+      prompt: "model B proposal",
+      requestedCapability: "entity.profile.read",
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/agent-fabric/runtime.ts
+++ b/agent-fabric/runtime.ts
@@ -1,0 +1,620 @@
+export const AGENT_RC1_IDENTITIES = {
+  representedEntityRef: "LAB-COMPANY-001",
+  requesterRef: "DIGITALME-ALPHA-TEST-001",
+  packRef: "AGENT-PACK-COMPANY-BASE-001@1.0.0",
+  agentId: "AGENT-LAB-COMPANY-001",
+  issuanceId: "AGENT-ISSUANCE-LAB-COMPANY-001",
+  wardenRef: "WARDEN-ALPHA-RC1-001",
+  modelABindingRef: "MODEL-BINDING-A-001",
+  modelBBindingRef: "MODEL-BINDING-B-001",
+} as const;
+
+export type AgentIssuanceDecision = "ALLOW" | "ESCALATE" | "DENY";
+export type ModelBindingDecisionStatus = "ALLOW" | "DENY";
+export type AgentRuntimeState = "ACTIVE" | "REVOKED";
+export type ModelBindingState = "ACTIVE" | "SUPERSEDED";
+
+export interface WardenIssuanceRequest {
+  requesterRef: string;
+  representedEntityRef: string;
+  packRef: string;
+  requestedAgentId: string;
+  requestedIssuanceId: string;
+  requestedCapabilities: readonly string[];
+  requestedAt: string;
+}
+
+export interface WardenAuthorityEnvelope {
+  agentId: string;
+  issuanceId: string;
+  representedEntityRef: string;
+  requesterRef: string;
+  packRef: string;
+  wardenRef: string;
+  issuanceDecisionRef: string;
+  decision: "ALLOW";
+  allowedCapabilities: readonly string[];
+  deniedCapabilities: readonly string[];
+  validFrom: string;
+  validUntil: string;
+  issuedAt: string;
+  lifecycleState: "ACTIVE";
+  authorityFingerprint: string;
+}
+
+export interface AgentIssuanceResult {
+  decision: AgentIssuanceDecision;
+  decisionRef: string;
+  reason: string;
+  envelope?: WardenAuthorityEnvelope;
+}
+
+export interface WardenBindingDecision {
+  decisionRef: string;
+  wardenRef: string;
+  decision: ModelBindingDecisionStatus;
+  agentId: string;
+  issuanceId: string;
+  adapterRef: string;
+  authorityFingerprint: string;
+  reason: string;
+}
+
+export interface WardenRevocationDecision {
+  decisionRef: string;
+  wardenRef: string;
+  agentId: string;
+  issuanceId: string;
+  authorityFingerprint: string;
+  revokedAt: string;
+  reason: string;
+}
+
+export interface ModelInvocationContext {
+  sessionId: string;
+  sequence: number;
+  prompt: string;
+  requestedCapability: string;
+}
+
+export interface ModelAdapter {
+  adapterRef: string;
+  providerRef: string;
+  modelRef: string;
+  invoke(context: ModelInvocationContext): string;
+}
+
+export interface AgentBindingIdentityGuard {
+  agentId: string;
+  issuanceId: string;
+  representedEntityRef: string;
+  authorityFingerprint: string;
+}
+
+export interface ModelBinding {
+  bindingRef: string;
+  bindingVersion: number;
+  agentId: string;
+  issuanceId: string;
+  representedEntityRef: string;
+  authorityFingerprint: string;
+  adapterRef: string;
+  providerRef: string;
+  modelRef: string;
+  purpose: string;
+  capabilityProfile: readonly string[];
+  activatedAt: string;
+  lifecycleState: ModelBindingState;
+  predecessorBindingRef?: string;
+  changeDecisionRef: string;
+  idempotencyKey: string;
+}
+
+export interface AgentSessionSnapshot {
+  sessionId: string;
+  agentId: string;
+  issuanceId: string;
+  openedAt: string;
+  invocationSequence: number;
+  continuityRef: string;
+}
+
+export interface ModelInvocationProposal {
+  proposalRef: string;
+  sessionId: string;
+  agentId: string;
+  issuanceId: string;
+  bindingRef: string;
+  modelRef: string;
+  requestedCapability: string;
+  output: string;
+  requiresWardenDecision: true;
+  authorized: false;
+  actionToken?: undefined;
+}
+
+export interface ActivateAgentRuntimeInput {
+  issuance?: WardenAuthorityEnvelope;
+  initialBindingRef: string;
+  initialBindingDecision: WardenBindingDecision;
+  adapterRegistry: readonly ModelAdapter[];
+  purpose: string;
+  capabilityProfile: readonly string[];
+  activatedAt: string;
+  idempotencyKey: string;
+}
+
+export interface SwapModelInput {
+  bindingRef: string;
+  bindingDecision: WardenBindingDecision;
+  identityGuard: AgentBindingIdentityGuard;
+  purpose: string;
+  capabilityProfile: readonly string[];
+  activatedAt: string;
+  idempotencyKey: string;
+}
+
+interface MutableSession {
+  sessionId: string;
+  openedAt: string;
+  invocationSequence: number;
+  continuityRef: string;
+}
+
+interface SwapMemo {
+  bindingRef: string;
+  adapterRef: string;
+  decisionRef: string;
+}
+
+function immutableStrings(values: readonly string[]): readonly string[] {
+  return Object.freeze([...values]);
+}
+
+function makeAuthorityFingerprint(input: {
+  agentId: string;
+  issuanceId: string;
+  representedEntityRef: string;
+  requesterRef: string;
+  packRef: string;
+  allowedCapabilities: readonly string[];
+  deniedCapabilities: readonly string[];
+  validFrom: string;
+  validUntil: string;
+}): string {
+  return [
+    "AF-AUTH-V1",
+    input.agentId,
+    input.issuanceId,
+    input.representedEntityRef,
+    input.requesterRef,
+    input.packRef,
+    [...input.allowedCapabilities].sort().join(","),
+    [...input.deniedCapabilities].sort().join(","),
+    input.validFrom,
+    input.validUntil,
+  ].join("|");
+}
+
+function cloneBinding(binding: ModelBinding): ModelBinding {
+  return {
+    ...binding,
+    capabilityProfile: [...binding.capabilityProfile],
+  };
+}
+
+export class DeterministicModelAdapter implements ModelAdapter {
+  readonly adapterRef: string;
+  readonly providerRef: string;
+  readonly modelRef: string;
+
+  constructor(input: { adapterRef: string; providerRef: string; modelRef: string }) {
+    this.adapterRef = input.adapterRef;
+    this.providerRef = input.providerRef;
+    this.modelRef = input.modelRef;
+  }
+
+  invoke(context: ModelInvocationContext): string {
+    return [
+      this.modelRef,
+      context.sessionId,
+      String(context.sequence),
+      context.requestedCapability,
+      context.prompt,
+    ].join(":");
+  }
+}
+
+export class SyntheticWardenAgentAuthority {
+  private readonly issuanceDecision: AgentIssuanceDecision;
+  private readonly approvedPackRefs: ReadonlySet<string>;
+  private readonly approvedAdapterRefs: ReadonlySet<string>;
+  private readonly allowedCapabilities: readonly string[];
+  private readonly deniedCapabilities: readonly string[];
+
+  constructor(input?: {
+    issuanceDecision?: AgentIssuanceDecision;
+    approvedPackRefs?: readonly string[];
+    approvedAdapterRefs?: readonly string[];
+    allowedCapabilities?: readonly string[];
+    deniedCapabilities?: readonly string[];
+  }) {
+    this.issuanceDecision = input?.issuanceDecision ?? "ALLOW";
+    this.approvedPackRefs = new Set(
+      input?.approvedPackRefs ?? [AGENT_RC1_IDENTITIES.packRef],
+    );
+    this.approvedAdapterRefs = new Set(
+      input?.approvedAdapterRefs ?? ["MODEL-ADAPTER-A-001", "MODEL-ADAPTER-B-001"],
+    );
+    this.allowedCapabilities = immutableStrings(
+      input?.allowedCapabilities ?? ["entity.profile.read", "service_request.create"],
+    );
+    this.deniedCapabilities = immutableStrings(
+      input?.deniedCapabilities ?? ["contract.execute"],
+    );
+  }
+
+  issue(request: WardenIssuanceRequest): AgentIssuanceResult {
+    const decisionRef = `WARDEN-AGENT-ISSUANCE:${request.requestedIssuanceId}`;
+
+    if (!this.approvedPackRefs.has(request.packRef)) {
+      return { decision: "DENY", decisionRef, reason: "agent_pack_not_approved" };
+    }
+
+    if (this.issuanceDecision === "DENY") {
+      return { decision: "DENY", decisionRef, reason: "warden_policy_denied" };
+    }
+
+    if (this.issuanceDecision === "ESCALATE") {
+      return { decision: "ESCALATE", decisionRef, reason: "manual_review_required" };
+    }
+
+    const validFrom = request.requestedAt;
+    const validUntil = "2026-08-14T07:10:00.000Z";
+    const authorityFingerprint = makeAuthorityFingerprint({
+      agentId: request.requestedAgentId,
+      issuanceId: request.requestedIssuanceId,
+      representedEntityRef: request.representedEntityRef,
+      requesterRef: request.requesterRef,
+      packRef: request.packRef,
+      allowedCapabilities: this.allowedCapabilities,
+      deniedCapabilities: this.deniedCapabilities,
+      validFrom,
+      validUntil,
+    });
+
+    const envelope: WardenAuthorityEnvelope = Object.freeze({
+      agentId: request.requestedAgentId,
+      issuanceId: request.requestedIssuanceId,
+      representedEntityRef: request.representedEntityRef,
+      requesterRef: request.requesterRef,
+      packRef: request.packRef,
+      wardenRef: AGENT_RC1_IDENTITIES.wardenRef,
+      issuanceDecisionRef: decisionRef,
+      decision: "ALLOW" as const,
+      allowedCapabilities: this.allowedCapabilities,
+      deniedCapabilities: this.deniedCapabilities,
+      validFrom,
+      validUntil,
+      issuedAt: request.requestedAt,
+      lifecycleState: "ACTIVE" as const,
+      authorityFingerprint,
+    });
+
+    return { decision: "ALLOW", decisionRef, reason: "bounded_agent_issuance", envelope };
+  }
+
+  authorizeBindingChange(
+    envelope: WardenAuthorityEnvelope,
+    adapterRef: string,
+    decisionRef: string,
+  ): WardenBindingDecision {
+    const approved = this.approvedAdapterRefs.has(adapterRef);
+    return {
+      decisionRef,
+      wardenRef: AGENT_RC1_IDENTITIES.wardenRef,
+      decision: approved ? "ALLOW" : "DENY",
+      agentId: envelope.agentId,
+      issuanceId: envelope.issuanceId,
+      adapterRef,
+      authorityFingerprint: envelope.authorityFingerprint,
+      reason: approved ? "model_adapter_approved" : "model_adapter_not_approved",
+    };
+  }
+
+  revoke(
+    envelope: WardenAuthorityEnvelope,
+    input: { decisionRef: string; revokedAt: string; reason: string },
+  ): WardenRevocationDecision {
+    return {
+      decisionRef: input.decisionRef,
+      wardenRef: AGENT_RC1_IDENTITIES.wardenRef,
+      agentId: envelope.agentId,
+      issuanceId: envelope.issuanceId,
+      authorityFingerprint: envelope.authorityFingerprint,
+      revokedAt: input.revokedAt,
+      reason: input.reason,
+    };
+  }
+}
+
+export class AgentRuntime {
+  private readonly issuance: WardenAuthorityEnvelope;
+  private readonly adapters: ReadonlyMap<string, ModelAdapter>;
+  private readonly bindings: ModelBinding[] = [];
+  private readonly sessions = new Map<string, MutableSession>();
+  private readonly swapMemos = new Map<string, SwapMemo>();
+  private runtimeState: AgentRuntimeState = "ACTIVE";
+  private activeBindingRef: string;
+  private revocation?: WardenRevocationDecision;
+
+  private constructor(
+    issuance: WardenAuthorityEnvelope,
+    adapters: ReadonlyMap<string, ModelAdapter>,
+    initialBinding: ModelBinding,
+  ) {
+    this.issuance = issuance;
+    this.adapters = adapters;
+    this.bindings.push(initialBinding);
+    this.activeBindingRef = initialBinding.bindingRef;
+  }
+
+  static activate(input: ActivateAgentRuntimeInput): AgentRuntime {
+    if (!input.issuance) {
+      throw new Error("warden_issuance_required");
+    }
+
+    const adapters = new Map(input.adapterRegistry.map((adapter) => [adapter.adapterRef, adapter]));
+    const adapter = adapters.get(input.initialBindingDecision.adapterRef);
+    if (!adapter) {
+      throw new Error("model_adapter_not_registered");
+    }
+
+    AgentRuntime.assertBindingDecision(input.issuance, input.initialBindingDecision);
+
+    const initialBinding: ModelBinding = {
+      bindingRef: input.initialBindingRef,
+      bindingVersion: 1,
+      agentId: input.issuance.agentId,
+      issuanceId: input.issuance.issuanceId,
+      representedEntityRef: input.issuance.representedEntityRef,
+      authorityFingerprint: input.issuance.authorityFingerprint,
+      adapterRef: adapter.adapterRef,
+      providerRef: adapter.providerRef,
+      modelRef: adapter.modelRef,
+      purpose: input.purpose,
+      capabilityProfile: immutableStrings(input.capabilityProfile),
+      activatedAt: input.activatedAt,
+      lifecycleState: "ACTIVE",
+      changeDecisionRef: input.initialBindingDecision.decisionRef,
+      idempotencyKey: input.idempotencyKey,
+    };
+
+    return new AgentRuntime(input.issuance, adapters, initialBinding);
+  }
+
+  private static assertBindingDecision(
+    issuance: WardenAuthorityEnvelope,
+    decision: WardenBindingDecision,
+  ): void {
+    if (decision.decision !== "ALLOW") {
+      throw new Error("warden_model_binding_denied");
+    }
+    if (decision.wardenRef !== issuance.wardenRef) {
+      throw new Error("binding_warden_mismatch");
+    }
+    if (decision.agentId !== issuance.agentId || decision.issuanceId !== issuance.issuanceId) {
+      throw new Error("binding_identity_mismatch");
+    }
+    if (decision.authorityFingerprint !== issuance.authorityFingerprint) {
+      throw new Error("binding_authority_mismatch");
+    }
+  }
+
+  private assertActive(): void {
+    if (this.runtimeState !== "ACTIVE") {
+      throw new Error("agent_issuance_revoked");
+    }
+  }
+
+  private assertIdentityGuard(guard: AgentBindingIdentityGuard): void {
+    if (
+      guard.agentId !== this.issuance.agentId ||
+      guard.issuanceId !== this.issuance.issuanceId ||
+      guard.representedEntityRef !== this.issuance.representedEntityRef ||
+      guard.authorityFingerprint !== this.issuance.authorityFingerprint
+    ) {
+      throw new Error("model_swap_identity_or_authority_drift");
+    }
+  }
+
+  identityGuard(): AgentBindingIdentityGuard {
+    return {
+      agentId: this.issuance.agentId,
+      issuanceId: this.issuance.issuanceId,
+      representedEntityRef: this.issuance.representedEntityRef,
+      authorityFingerprint: this.issuance.authorityFingerprint,
+    };
+  }
+
+  authorityEnvelope(): WardenAuthorityEnvelope {
+    return {
+      ...this.issuance,
+      allowedCapabilities: [...this.issuance.allowedCapabilities],
+      deniedCapabilities: [...this.issuance.deniedCapabilities],
+    };
+  }
+
+  state(): AgentRuntimeState {
+    return this.runtimeState;
+  }
+
+  bindingHistory(): ModelBinding[] {
+    return this.bindings.map(cloneBinding);
+  }
+
+  activeBinding(): ModelBinding {
+    const binding = this.bindings.find((candidate) => candidate.bindingRef === this.activeBindingRef);
+    if (!binding) {
+      throw new Error("active_model_binding_missing");
+    }
+    return cloneBinding(binding);
+  }
+
+  openSession(input: { sessionId: string; openedAt: string }): AgentSessionSnapshot {
+    this.assertActive();
+    const existing = this.sessions.get(input.sessionId);
+    if (existing) {
+      return this.sessionSnapshot(existing);
+    }
+
+    const session: MutableSession = {
+      sessionId: input.sessionId,
+      openedAt: input.openedAt,
+      invocationSequence: 0,
+      continuityRef: `AGENT-SESSION-CONTINUITY:${input.sessionId}`,
+    };
+    this.sessions.set(input.sessionId, session);
+    return this.sessionSnapshot(session);
+  }
+
+  session(sessionId: string): AgentSessionSnapshot {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error("agent_session_not_found");
+    }
+    return this.sessionSnapshot(session);
+  }
+
+  private sessionSnapshot(session: MutableSession): AgentSessionSnapshot {
+    return {
+      sessionId: session.sessionId,
+      agentId: this.issuance.agentId,
+      issuanceId: this.issuance.issuanceId,
+      openedAt: session.openedAt,
+      invocationSequence: session.invocationSequence,
+      continuityRef: session.continuityRef,
+    };
+  }
+
+  invoke(input: {
+    sessionId: string;
+    prompt: string;
+    requestedCapability: string;
+  }): ModelInvocationProposal {
+    this.assertActive();
+    const session = this.sessions.get(input.sessionId);
+    if (!session) {
+      throw new Error("agent_session_not_found");
+    }
+
+    const binding = this.activeBinding();
+    const adapter = this.adapters.get(binding.adapterRef);
+    if (!adapter) {
+      throw new Error("active_model_adapter_missing");
+    }
+
+    session.invocationSequence += 1;
+    const output = adapter.invoke({
+      sessionId: session.sessionId,
+      sequence: session.invocationSequence,
+      prompt: input.prompt,
+      requestedCapability: input.requestedCapability,
+    });
+
+    return {
+      proposalRef: `AGENT-PROPOSAL:${session.sessionId}:${session.invocationSequence}`,
+      sessionId: session.sessionId,
+      agentId: this.issuance.agentId,
+      issuanceId: this.issuance.issuanceId,
+      bindingRef: binding.bindingRef,
+      modelRef: binding.modelRef,
+      requestedCapability: input.requestedCapability,
+      output,
+      requiresWardenDecision: true,
+      authorized: false,
+      actionToken: undefined,
+    };
+  }
+
+  swapModel(input: SwapModelInput): ModelBinding {
+    this.assertActive();
+    this.assertIdentityGuard(input.identityGuard);
+
+    const memo = this.swapMemos.get(input.idempotencyKey);
+    if (memo) {
+      if (
+        memo.bindingRef !== input.bindingRef ||
+        memo.adapterRef !== input.bindingDecision.adapterRef ||
+        memo.decisionRef !== input.bindingDecision.decisionRef
+      ) {
+        throw new Error("model_swap_idempotency_conflict");
+      }
+      const replay = this.bindings.find((binding) => binding.bindingRef === memo.bindingRef);
+      if (!replay) {
+        throw new Error("model_swap_replay_binding_missing");
+      }
+      return cloneBinding(replay);
+    }
+
+    AgentRuntime.assertBindingDecision(this.issuance, input.bindingDecision);
+    const adapter = this.adapters.get(input.bindingDecision.adapterRef);
+    if (!adapter) {
+      throw new Error("model_adapter_not_registered");
+    }
+
+    const previousIndex = this.bindings.findIndex(
+      (binding) => binding.bindingRef === this.activeBindingRef,
+    );
+    if (previousIndex < 0) {
+      throw new Error("active_model_binding_missing");
+    }
+    const previous = this.bindings[previousIndex];
+    this.bindings[previousIndex] = { ...previous, lifecycleState: "SUPERSEDED" };
+
+    const nextBinding: ModelBinding = {
+      bindingRef: input.bindingRef,
+      bindingVersion: previous.bindingVersion + 1,
+      agentId: this.issuance.agentId,
+      issuanceId: this.issuance.issuanceId,
+      representedEntityRef: this.issuance.representedEntityRef,
+      authorityFingerprint: this.issuance.authorityFingerprint,
+      adapterRef: adapter.adapterRef,
+      providerRef: adapter.providerRef,
+      modelRef: adapter.modelRef,
+      purpose: input.purpose,
+      capabilityProfile: immutableStrings(input.capabilityProfile),
+      activatedAt: input.activatedAt,
+      lifecycleState: "ACTIVE",
+      predecessorBindingRef: previous.bindingRef,
+      changeDecisionRef: input.bindingDecision.decisionRef,
+      idempotencyKey: input.idempotencyKey,
+    };
+
+    this.bindings.push(nextBinding);
+    this.activeBindingRef = nextBinding.bindingRef;
+    this.swapMemos.set(input.idempotencyKey, {
+      bindingRef: nextBinding.bindingRef,
+      adapterRef: nextBinding.adapterRef,
+      decisionRef: input.bindingDecision.decisionRef,
+    });
+    return cloneBinding(nextBinding);
+  }
+
+  applyRevocation(decision: WardenRevocationDecision): void {
+    if (
+      decision.wardenRef !== this.issuance.wardenRef ||
+      decision.agentId !== this.issuance.agentId ||
+      decision.issuanceId !== this.issuance.issuanceId ||
+      decision.authorityFingerprint !== this.issuance.authorityFingerprint
+    ) {
+      throw new Error("revocation_authority_mismatch");
+    }
+    this.revocation = { ...decision };
+    this.runtimeState = "REVOKED";
+  }
+
+  revocationDecision(): WardenRevocationDecision | undefined {
+    return this.revocation ? { ...this.revocation } : undefined;
+  }
+}

--- a/agent-fabric/runtime.ts
+++ b/agent-fabric/runtime.ts
@@ -163,12 +163,15 @@ interface MutableSession {
 
 interface SwapMemo {
   bindingRef: string;
-  adapterRef: string;
-  decisionRef: string;
+  requestFingerprint: string;
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return [...new Set(values)];
 }
 
 function immutableStrings(values: readonly string[]): readonly string[] {
-  return Object.freeze([...values]);
+  return Object.freeze(uniqueStrings(values));
 }
 
 function makeAuthorityFingerprint(input: {
@@ -196,11 +199,23 @@ function makeAuthorityFingerprint(input: {
   ].join("|");
 }
 
+function makeSwapRequestFingerprint(input: SwapModelInput): string {
+  return [
+    input.bindingRef,
+    input.bindingDecision.adapterRef,
+    input.bindingDecision.decisionRef,
+    input.identityGuard.agentId,
+    input.identityGuard.issuanceId,
+    input.identityGuard.representedEntityRef,
+    input.identityGuard.authorityFingerprint,
+    input.purpose,
+    [...input.capabilityProfile].sort().join(","),
+    input.activatedAt,
+  ].join("|");
+}
+
 function cloneBinding(binding: ModelBinding): ModelBinding {
-  return {
-    ...binding,
-    capabilityProfile: [...binding.capabilityProfile],
-  };
+  return { ...binding, capabilityProfile: [...binding.capabilityProfile] };
 }
 
 export class DeterministicModelAdapter implements ModelAdapter {
@@ -229,7 +244,7 @@ export class SyntheticWardenAgentAuthority {
   private readonly issuanceDecision: AgentIssuanceDecision;
   private readonly approvedPackRefs: ReadonlySet<string>;
   private readonly approvedAdapterRefs: ReadonlySet<string>;
-  private readonly allowedCapabilities: readonly string[];
+  private readonly allowedCapabilities: ReadonlySet<string>;
   private readonly deniedCapabilities: readonly string[];
 
   constructor(input?: {
@@ -240,22 +255,27 @@ export class SyntheticWardenAgentAuthority {
     deniedCapabilities?: readonly string[];
   }) {
     this.issuanceDecision = input?.issuanceDecision ?? "ALLOW";
-    this.approvedPackRefs = new Set(
-      input?.approvedPackRefs ?? [AGENT_RC1_IDENTITIES.packRef],
-    );
+    this.approvedPackRefs = new Set(input?.approvedPackRefs ?? [AGENT_RC1_IDENTITIES.packRef]);
     this.approvedAdapterRefs = new Set(
       input?.approvedAdapterRefs ?? ["MODEL-ADAPTER-A-001", "MODEL-ADAPTER-B-001"],
     );
-    this.allowedCapabilities = immutableStrings(
+    this.allowedCapabilities = new Set(
       input?.allowedCapabilities ?? ["entity.profile.read", "service_request.create"],
     );
-    this.deniedCapabilities = immutableStrings(
-      input?.deniedCapabilities ?? ["contract.execute"],
-    );
+    this.deniedCapabilities = immutableStrings(input?.deniedCapabilities ?? ["contract.execute"]);
   }
 
   issue(request: WardenIssuanceRequest): AgentIssuanceResult {
     const decisionRef = `WARDEN-AGENT-ISSUANCE:${request.requestedIssuanceId}`;
+
+    if (
+      request.requesterRef !== AGENT_RC1_IDENTITIES.requesterRef ||
+      request.representedEntityRef !== AGENT_RC1_IDENTITIES.representedEntityRef ||
+      request.requestedAgentId !== AGENT_RC1_IDENTITIES.agentId ||
+      request.requestedIssuanceId !== AGENT_RC1_IDENTITIES.issuanceId
+    ) {
+      return { decision: "DENY", decisionRef, reason: "registry_identity_resolution_mismatch" };
+    }
 
     if (!this.approvedPackRefs.has(request.packRef)) {
       return { decision: "DENY", decisionRef, reason: "agent_pack_not_approved" };
@@ -269,6 +289,14 @@ export class SyntheticWardenAgentAuthority {
       return { decision: "ESCALATE", decisionRef, reason: "manual_review_required" };
     }
 
+    const requestedCapabilities = uniqueStrings(request.requestedCapabilities);
+    const allowedCapabilities = immutableStrings(
+      requestedCapabilities.filter((capability) => this.allowedCapabilities.has(capability)),
+    );
+    const deniedCapabilities = immutableStrings([
+      ...this.deniedCapabilities,
+      ...requestedCapabilities.filter((capability) => !this.allowedCapabilities.has(capability)),
+    ]);
     const validFrom = request.requestedAt;
     const validUntil = "2026-08-14T07:10:00.000Z";
     const authorityFingerprint = makeAuthorityFingerprint({
@@ -277,8 +305,8 @@ export class SyntheticWardenAgentAuthority {
       representedEntityRef: request.representedEntityRef,
       requesterRef: request.requesterRef,
       packRef: request.packRef,
-      allowedCapabilities: this.allowedCapabilities,
-      deniedCapabilities: this.deniedCapabilities,
+      allowedCapabilities,
+      deniedCapabilities,
       validFrom,
       validUntil,
     });
@@ -292,8 +320,8 @@ export class SyntheticWardenAgentAuthority {
       wardenRef: AGENT_RC1_IDENTITIES.wardenRef,
       issuanceDecisionRef: decisionRef,
       decision: "ALLOW" as const,
-      allowedCapabilities: this.allowedCapabilities,
-      deniedCapabilities: this.deniedCapabilities,
+      allowedCapabilities,
+      deniedCapabilities,
       validFrom,
       validUntil,
       issuedAt: request.requestedAt,
@@ -364,13 +392,14 @@ export class AgentRuntime {
       throw new Error("warden_issuance_required");
     }
 
+    AgentRuntime.assertBindingDecision(input.issuance, input.initialBindingDecision);
+    AgentRuntime.assertCapabilityProfile(input.issuance, input.capabilityProfile);
+
     const adapters = new Map(input.adapterRegistry.map((adapter) => [adapter.adapterRef, adapter]));
     const adapter = adapters.get(input.initialBindingDecision.adapterRef);
     if (!adapter) {
       throw new Error("model_adapter_not_registered");
     }
-
-    AgentRuntime.assertBindingDecision(input.issuance, input.initialBindingDecision);
 
     const initialBinding: ModelBinding = {
       bindingRef: input.initialBindingRef,
@@ -408,6 +437,16 @@ export class AgentRuntime {
     }
     if (decision.authorityFingerprint !== issuance.authorityFingerprint) {
       throw new Error("binding_authority_mismatch");
+    }
+  }
+
+  private static assertCapabilityProfile(
+    issuance: WardenAuthorityEnvelope,
+    capabilityProfile: readonly string[],
+  ): void {
+    const allowed = new Set(issuance.allowedCapabilities);
+    if (capabilityProfile.some((capability) => !allowed.has(capability))) {
+      throw new Error("model_binding_capability_expansion");
     }
   }
 
@@ -540,14 +579,12 @@ export class AgentRuntime {
   swapModel(input: SwapModelInput): ModelBinding {
     this.assertActive();
     this.assertIdentityGuard(input.identityGuard);
+    AgentRuntime.assertCapabilityProfile(this.issuance, input.capabilityProfile);
 
+    const requestFingerprint = makeSwapRequestFingerprint(input);
     const memo = this.swapMemos.get(input.idempotencyKey);
     if (memo) {
-      if (
-        memo.bindingRef !== input.bindingRef ||
-        memo.adapterRef !== input.bindingDecision.adapterRef ||
-        memo.decisionRef !== input.bindingDecision.decisionRef
-      ) {
+      if (memo.bindingRef !== input.bindingRef || memo.requestFingerprint !== requestFingerprint) {
         throw new Error("model_swap_idempotency_conflict");
       }
       const replay = this.bindings.find((binding) => binding.bindingRef === memo.bindingRef);
@@ -595,8 +632,7 @@ export class AgentRuntime {
     this.activeBindingRef = nextBinding.bindingRef;
     this.swapMemos.set(input.idempotencyKey, {
       bindingRef: nextBinding.bindingRef,
-      adapterRef: nextBinding.adapterRef,
-      decisionRef: input.bindingDecision.decisionRef,
+      requestFingerprint,
     });
     return cloneBinding(nextBinding);
   }

--- a/docs/alpha-node/ALPHA-AGENT-RUNTIME-BINDING-001.md
+++ b/docs/alpha-node/ALPHA-AGENT-RUNTIME-BINDING-001.md
@@ -1,0 +1,63 @@
+# ALPHA-AGENT-RUNTIME-BINDING-001
+
+Synthetic AF-002 / AF-003 conformance package for the Alpha Agent Fabric.
+
+## Canonical separation
+
+`ENTITY ≠ AGENT ≠ LLM ≠ AUTHORITY`
+
+- Entity: represented principal.
+- Agent: Warden-issued governed runtime interface.
+- Model: replaceable cognition provider/adapter.
+- Warden: authority and policy issuer.
+
+The model cannot issue Agent identity, enlarge authority, generate an executable action token, or survive Warden revocation by changing provider.
+
+## Synthetic identities
+
+- Entity: `LAB-COMPANY-001`
+- Requester: `DIGITALME-ALPHA-TEST-001`
+- Agent Pack: `AGENT-PACK-COMPANY-BASE-001@1.0.0`
+- Agent: `AGENT-LAB-COMPANY-001`
+- Issuance: `AGENT-ISSUANCE-LAB-COMPANY-001`
+- Warden: `WARDEN-ALPHA-RC1-001`
+- Model A binding: `MODEL-BINDING-A-001`
+- Model B binding: `MODEL-BINDING-B-001`
+
+## Executable proof
+
+1. Warden evaluates the issuance request.
+2. Only `ALLOW` produces an ACTIVE bounded authority envelope.
+3. A separately Warden-approved Model A binding activates the Agent runtime.
+4. Model A may emit proposals, but proposals carry no authorization/action token.
+5. Warden separately approves Model B.
+6. Runtime supersedes Model A with Model B while preserving `agent_id`, `issuance_id`, represented entity and authority fingerprint.
+7. Existing session continuity survives the swap.
+8. Binding lineage records the predecessor and Warden change decision.
+9. Warden revocation terminates later invocation regardless of active model/provider.
+
+## Fail-closed vectors
+
+- no Warden issuance -> no runtime;
+- `DENY` or `ESCALATE` issuance -> no ACTIVE Agent;
+- unapproved model adapter -> no binding change;
+- Agent/issuance/entity/authority drift during swap -> rejected;
+- duplicate swap idempotency key -> no duplicate active binding;
+- model output -> proposal only, never authority;
+- post-revocation invocation -> rejected;
+- no external network/provider dependency in this conformance package.
+
+## Provider posture
+
+The adapters are deterministic fixtures. Supabase, Neon and external LLM APIs are not required to prove AF-002/AF-003 semantics. Provider-specific model adapters can be added later behind the same interface and Warden binding decision contract.
+
+This package does not claim to be the production Warden service or a production model gateway. It proves the runtime boundary before provider activation.
+
+## Governance
+
+- `Believers-common-group/SynergyzeGovernance#17`
+- `Believers-common-group/SynergyzeGovernance#25`
+- `Believers-common-group/SynergyzeGovernance#13`
+- `Believers-common-group/mcp-node-synnergyze#39`
+
+Promotion into `genesis` requires the full repository test, lint, type-check and bridge/compute gates to remain green.

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "scripts": {
     "start": "node --experimental-strip-types --no-warnings=ExperimentalWarnings src/app.ts",
     "type-check": "tsc --noEmit",
-    "lint": "eslint --ext .ts src api rc1 compute",
+    "lint": "eslint --ext .ts src api rc1 compute agent-fabric",
     "test": "vitest",
     "test:bridge": "vitest run api/registry-bridge.test.ts",
     "test:rc1": "vitest run rc1/runtime.test.ts",
     "test:compute": "vitest run api/compute-plane.test.ts compute/runtime.test.ts",
     "test:compute-proof": "vitest run compute/runtime.test.ts",
+    "test:agent": "vitest run agent-fabric/runtime.test.ts",
     "probe:apple-mpp": "bash scripts/bootstrap-apple-mpp-runner.sh",
     "compile:apple-mpp": "bash native/apple-mpp/build-probe.sh",
     "debug": "mcp-inspector npm start"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
     "noUnusedLocals": true,
     "resolveJsonModule": true
   },
-  "include": ["api/**/*.ts", "rc1/**/*.ts", "compute/**/*.ts"],
+  "include": ["api/**/*.ts", "rc1/**/*.ts", "compute/**/*.ts", "agent-fabric/**/*.ts"],
   "exclude": ["src/**", "node_modules"]
 }


### PR DESCRIPTION
Implements Governance #25 / #17 AF-002 and AF-003 on top of the current Alpha runtime.

Scope:
- bounded synthetic Warden Agent issuance envelope;
- Warden-gated model binding decisions;
- provider-neutral deterministic model adapter interface;
- same Agent identity + issuance across Model A → Model B;
- session continuity and binding lineage;
- proposal-only model output with no action token;
- Warden revocation blocks later invocation;
- negative tests for missing/denied/escalated issuance, unapproved adapters, identity/authority drift and idempotent swap replay;
- no external network, Supabase, Neon or real model provider requirement.

This does not implement a production Warden service or production model gateway. `genesis` remains Production. The Apple MPP/compute-plane work already on `genesis` is untouched and must remain green.

Governance: Believers-common-group/SynergyzeGovernance#25 and #17
Prior RC1 runtime proof: #39