### PR TITLE
Add governed Alpha/Newton Metal DevOps tool surface

### DIFF
--- a/.github/workflows/apple-metal-canary.yml
+++ b/.github/workflows/apple-metal-canary.yml
@@ -1,0 +1,34 @@
+name: Apple Metal canary
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    paths:
+      - 'src/tools/registerAppleRunnerCanary.ts'
+      - 'src/tools/registerAppleRunnerCanary.test.ts'
+      - 'src/commands/start-alpha-newton-server.ts'
+      - '.github/workflows/apple-metal-canary.yml'
+
+jobs:
+  metal-canary:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Show Apple runner identity
+        run: |
+          sw_vers
+          xcodebuild -version
+          xcrun --find swift
+
+      - name: Run APPLE-RUNNER-001 Metal canary test
+        run: npm test -- --run src/tools/registerAppleRunnerCanary.test.ts

--- a/.github/workflows/apple-metal-canary.yml
+++ b/.github/workflows/apple-metal-canary.yml
@@ -1,4 +1,4 @@
-name: Apple Metal canary
+name: Apple runner governed checks
 
 on:
   pull_request:
@@ -6,11 +6,13 @@ on:
     paths:
       - 'src/tools/registerAppleRunnerCanary.ts'
       - 'src/tools/registerAppleRunnerCanary.test.ts'
+      - 'src/tools/registerAppleRunnerBuild.ts'
+      - 'src/tools/registerAppleRunnerBuild.test.ts'
       - 'src/commands/start-alpha-newton-server.ts'
       - '.github/workflows/apple-metal-canary.yml'
 
 jobs:
-  metal-canary:
+  apple-runner:
     runs-on: macos-latest
 
     steps:
@@ -30,5 +32,8 @@ jobs:
           xcodebuild -version
           xcrun --find swift
 
-      - name: Run APPLE-RUNNER-001 Metal canary test
-        run: npm test -- --run src/tools/registerAppleRunnerCanary.test.ts
+      - name: Run APPLE-RUNNER-001 governed execution tests
+        run: >-
+          npm test -- --run
+          src/tools/registerAppleRunnerCanary.test.ts
+          src/tools/registerAppleRunnerBuild.test.ts

--- a/.github/workflows/datadog-synthetics.yml
+++ b/.github/workflows/datadog-synthetics.yml
@@ -1,15 +1,6 @@
-# This workflow will trigger Datadog Synthetic tests within your Datadog organisation
-# For more information on running Synthetic tests within your GitHub workflows see: https://docs.datadoghq.com/synthetics/cicd_integrations/github_actions/
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# To get started:
-
-# 1. Add your Datadog API (DD_API_KEY) and Application Key (DD_APP_KEY) as secrets to your GitHub repository. For more information, see: https://docs.datadoghq.com/account_management/api-app-keys/.
-# 2. Start using the action within your workflow
+# This workflow triggers Datadog Synthetic tests when repository credentials are configured.
+# If the Datadog secrets are unavailable (for example in a new environment or restricted PR),
+# the workflow records an explicit skip instead of failing an otherwise unrelated change.
 
 name: Run Datadog Synthetic tests
 
@@ -22,17 +13,31 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
 
     steps:
     - uses: actions/checkout@v4
 
-    # Run Synthetic tests within your GitHub workflow.
-    # For additional configuration options visit the action within the marketplace: https://github.com/marketplace/actions/datadog-synthetics-ci
+    - name: Check Datadog credentials
+      id: datadog-credentials
+      shell: bash
+      run: |
+        if [[ -n "$DD_API_KEY" && -n "$DD_APP_KEY" ]]; then
+          echo "available=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "available=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Run Datadog Synthetic tests
+      if: steps.datadog-credentials.outputs.available == 'true'
       uses: DataDog/synthetics-ci-github-action@87b505388a22005bb8013481e3f73a367b9a53eb # v1.4.0
       with:
-        api_key: ${{secrets.DD_API_KEY}}
-        app_key: ${{secrets.DD_APP_KEY}}
-        test_search_query: 'tag:e2e-tests' #Modify this tag to suit your tagging strategy
+        api_key: ${{ env.DD_API_KEY }}
+        app_key: ${{ env.DD_APP_KEY }}
+        test_search_query: 'tag:e2e-tests'
 
-
+    - name: Datadog synthetics not configured
+      if: steps.datadog-credentials.outputs.available != 'true'
+      run: echo "::notice::Skipping Datadog Synthetic tests because DD_API_KEY/DD_APP_KEY are not configured for this run."

--- a/docs/ALPHA_NEWTON_AGENTIC_BUILDER.md
+++ b/docs/ALPHA_NEWTON_AGENTIC_BUILDER.md
@@ -1,0 +1,116 @@
+# Alpha Node / Newton Agentic Builder Tool Surface
+
+Status: first implementation slice  
+Tool pack: `ALPHA-NEWTON-METAL-TOOLS-001`  
+Authority state: planning-only until a Warden-issued capability is supplied
+
+## Purpose
+
+This package exposes the Apple Metal / Metal Performance Shaders material as governed MCP tools that an agentic DevOps builder can reason over. Newton is treated as a builder/operator surface, not as a canonical registry, policy engine, evidence store, or execution authority.
+
+The canonical boundary remains:
+
+`DigitalMe -> Alpha Registry -> Warden -> tool capability -> runner -> evidence -> effect`
+
+The builder may discover tools, create plans, request authority, route work, and later invoke provider adapters. It must not become a second source of truth.
+
+## Current tools
+
+| Tool | Function | Side effect |
+| --- | --- | --- |
+| `alphaNewtonListCapabilities` | Discover Metal/MPS capability families and execution boundary | None |
+| `alphaNewtonPlanMetalWorkload` | Select Metal/MPS framework candidates and produce build/test/evidence checks | None |
+| `alphaNewtonRouteExecutionTarget` | Decide whether work stays local or needs a remote Apple runner | None |
+| `alphaNewtonPlanDevOpsRun` | Produce a governed DevOps run plan using the Alpha network grammar | None |
+| `alphaNewtonCreateAuthorityEnvelope` | Produce a pending Warden authority request envelope | None |
+
+Every tool in this first slice is read-only. `executionAllowed` is deliberately `false` in generated plans/envelopes.
+
+## Metal documentation -> agentic tool mapping
+
+The uploaded Metal documentation is represented as reusable workload classes rather than one-off prompts:
+
+- Compute workflows -> `workloadClass=compute`
+- Argument buffers, buffers, textures, heaps and synchronization -> `workloadClass=resource-management`
+- Metal Performance Shaders image/filter primitives -> `workloadClass=image-processing`
+- MPSGraph tensor, FFT, inference and training workflows -> `tensor-graph`, `ml-inference`, or `ml-training`
+- Render pipelines and MetalFX opportunities -> `render`
+- Ray tracing and intersection workloads -> `ray-tracing`
+
+This preserves the distinction between a capability description and an authorized execution.
+
+## Host/runtime split
+
+Metal execution requires an Apple platform with Metal support. A Linux or Windows Alpha control-plane machine can still:
+
+1. inspect and plan the workload;
+2. generate a governed DevOps run;
+3. resolve an Apple runner;
+4. request a Warden capability;
+5. send the authorized change/run to the runner through a later provider adapter;
+6. receive build, test, timing and correctness evidence;
+7. record the resulting effect back through the Alpha evidence/runtime path.
+
+The non-Apple host must never pretend to have executed Metal locally.
+
+## Start the standalone MCP surface
+
+```bash
+npm start -- start-alpha-newton-server
+```
+
+The standalone command intentionally avoids Algolia authentication and starts only the Alpha/Newton tool pack over stdio.
+
+A generic MCP client entry can use:
+
+```json
+{
+  "mcpServers": {
+    "alpha-newton": {
+      "command": "npm",
+      "args": ["start", "--", "start-alpha-newton-server"]
+    }
+  }
+}
+```
+
+Run it from this repository or replace the command with the packaged executable once a release artifact exists.
+
+## Newton builder connection modes
+
+Use the least-coupled option supported by the builder environment:
+
+1. **Native MCP** — point the builder at the `alpha-newton` stdio/server adapter.
+2. **Workflow bridge** — if the builder uses n8n/Make or an equivalent workflow engine, place the MCP invocation behind a controlled workflow node; pass only Registry references and Warden capability references, never raw estate secrets.
+3. **OpenAPI/HTTP adapter** — add a transport adapter around the same tool contracts if the builder cannot consume MCP directly. The HTTP layer remains an adapter, not a new tool authority.
+
+No public Newton-specific builder API is assumed by this repository. A Newton workspace endpoint, API contract, or supported MCP configuration should be added only when it is available from the user's actual workspace or Newton documentation.
+
+## Warden gate
+
+A future executing adapter must reject a request unless all of the following resolve:
+
+- `digitalMeId`
+- represented entity / workspace context
+- `authorityRef`
+- requested tool and operation scope
+- target repository/environment/runner
+- validity window
+- evidence requirements
+- revocation state
+
+The agent can recommend and prepare. Warden authorizes. The runner executes. River/evidence records what happened.
+
+## First executable follow-up
+
+Do not jump directly to production deployment. The next implementation slice should add one Apple runner adapter with a synthetic workload only:
+
+1. generate a tiny Metal compute fixture;
+2. compile on a declared macOS runner;
+3. run a deterministic input/output test;
+4. capture Xcode/SDK, OS, device, commit, build log, test output and timing;
+5. hash/store those artifacts;
+6. return an effect object;
+7. keep deployment and production writes disabled.
+
+That thin slice proves the control-plane-to-Apple-runner boundary without giving the builder arbitrary shell or infrastructure authority.

--- a/docs/alpha-newton-metal-tools.md
+++ b/docs/alpha-newton-metal-tools.md
@@ -1,0 +1,56 @@
+# Alpha Node / Newton Agentic Builder — Metal Tool Pack
+
+This slice exposes Apple Metal/MPS planning capabilities to the Newton agentic-builder surface through MCP while preserving Alpha Node governance boundaries.
+
+## Architectural position
+
+Newton is a builder/operator surface. It is not a Registry, Warden, or source of authority.
+
+```text
+Newton builder / DevOps surface
+  -> Alpha/Newton MCP tools
+  -> Registry context
+  -> Warden authority/capability
+  -> build or execution adapter
+  -> evidence
+  -> Registry Effect / River evidence path
+```
+
+Planning and recommendation do not imply authorization. All planning tools return `executionAllowed: false` and identify the next Warden gate.
+
+## Planning tools
+
+- `alphaNewtonListCapabilities`
+- `alphaNewtonPlanMetalWorkload`
+- `alphaNewtonRouteExecutionTarget`
+- `alphaNewtonPlanDevOpsRun`
+- `alphaNewtonCreateAuthorityEnvelope`
+
+Workload classes map to Metal compute, Metal Performance Shaders, MPSGraph, rendering, MetalFX, ray tracing, and resource-management patterns.
+
+## APPLE-RUNNER-001
+
+`appleRunnerRunMetalCanary` is the first executing adapter. It is intentionally constrained to the deterministic `vector-add-f32-v1` Metal fixture.
+
+Execution invariants:
+
+1. The runner must be macOS.
+2. The tool accepts no executable, script, path, or arbitrary command argument.
+3. The process command is fixed to `xcrun swift <generated-fixed-fixture>` with `shell: false`.
+4. Authority is supplied as an HMAC-SHA256 Warden capability token using `ALPHA_WARDEN_HMAC_SECRET` from the runner environment; the secret is never accepted as a tool argument.
+5. Capability payload must be `ALPHA-WARDEN-CAPABILITY-001`, `issuedBy: WARDEN`, `status: AUTHORIZED`, scoped to `APPLE-RUNNER-001:METAL-CANARY`, bound to the requested runner and tool, and unexpired.
+6. Each capability contains a nonce. The runner writes an exclusive-use replay marker before execution; reuse is rejected.
+7. The generated fixture compiles an embedded Metal kernel at runtime, adds `[1,2,3,4]` to `[10,20,30,40]`, and requires `[11,22,33,44]`.
+8. Evidence contains fixture identity, Metal device identity, OS version, correctness, CPU elapsed time, GPU elapsed time when available, capability identity/context, and execution timestamp.
+9. Temporary source is removed after the run.
+10. Output is bounded and execution is time-limited.
+
+Default replay markers live under the runner temporary directory. Set `ALPHA_WARDEN_REPLAY_DIR` to a durable runner-local directory before using the canary for assurance beyond ephemeral testing.
+
+## Execution topology
+
+A Linux/Gram Alpha control-plane host may plan workloads, request Warden authority, dispatch work to an identified Apple runner, and ingest evidence. It must not claim local Metal execution. Metal workloads are routed to a macOS Apple runner.
+
+## Current boundary
+
+This slice does **not** add arbitrary shell execution, production deployment, raw Registry/database credentials, or a Newton-private API assumption. APPLE-RUNNER-001 proves only the smallest governed execution path required before broader build/deploy adapters are considered.

--- a/docs/apple-runner-governed-build.md
+++ b/docs/apple-runner-governed-build.md
@@ -1,0 +1,89 @@
+# APPLE-RUNNER-001 Governed Build Adapter
+
+`appleRunnerBuildSwiftArtifact` is the second executing tool on the Alpha/Newton Apple runner surface. It extends the proven Metal canary into a fixed build/test/artifact workflow without introducing arbitrary shell access.
+
+## Fixed workload
+
+The only accepted fixture is `metal-vector-add-package-v1`.
+
+The adapter generates a deterministic local Swift package containing:
+
+- `AlphaMetalCore` — Metal vector-add implementation;
+- `alpha-metal-artifact` — release executable;
+- `AlphaMetalCoreTests` — a physical Metal correctness test.
+
+The package is built with SwiftPM in release mode, tested, and then the built executable is executed again as an artifact self-test. The expected vector is always `[11, 22, 33, 44]`.
+
+## Authority boundary
+
+Execution requires a Warden capability with:
+
+- schema `ALPHA-WARDEN-CAPABILITY-001`;
+- `issuedBy: WARDEN`;
+- `status: AUTHORIZED`;
+- tool `appleRunnerBuildSwiftArtifact`;
+- runner bound to the requested `runnerRef`;
+- scope `APPLE-RUNNER-001:SWIFT-BUILD`;
+- principal and workspace context;
+- valid issue/expiry times;
+- a single-use nonce.
+
+`ALPHA_WARDEN_HMAC_SECRET` is runner configuration and is never accepted through MCP arguments.
+
+A separate `ALPHA_ARTIFACT_HMAC_SECRET` signs the artifact manifest. Separating execution authority verification from artifact attestation prevents one key from silently serving both purposes.
+
+## Command allow-list
+
+The MCP tool accepts no executable, shell expression, package path, output path, build flags or user-defined script. Internally it may run only the fixed sequence:
+
+1. `xcrun swift build -c release --product alpha-metal-artifact`
+2. `xcrun swift test -c release`
+3. `xcrun swift build -c release --show-bin-path`
+4. the built fixed executable with zero arguments
+5. `sw_vers -productVersion`
+6. `xcodebuild -version`
+7. `xcrun swift --version`
+
+All child processes use `shell: false`, bounded output and a hard execution timeout.
+
+## Artifact and evidence
+
+The output executable is copied to a runner-controlled artifact directory. Configure `ALPHA_APPLE_ARTIFACT_DIR` for durable runner-local storage. Without it, the adapter uses the runner temporary directory and reports that durable storage is not configured.
+
+Each build persists:
+
+- `alpha-metal-artifact`;
+- `build.log`;
+- `test.log`;
+- `manifest.json`;
+- `manifest.sig`.
+
+The manifest includes:
+
+- artifact SHA-256 and size;
+- deterministic source SHA-256;
+- build/test log hashes;
+- physical Metal self-test evidence;
+- macOS, Xcode and Swift identities;
+- GitHub repository/commit provenance when present;
+- DigitalMe principal/workspace/capability context;
+- generation timestamp.
+
+The returned reference uses the semantic form:
+
+`apple-runner://APPLE-RUNNER-001/<run-id>/alpha-metal-artifact`
+
+The local filesystem path is intentionally not part of the MCP input contract.
+
+## Current security posture
+
+The adapter still does **not** permit:
+
+- arbitrary shell or command execution;
+- arbitrary repositories or user-supplied source code;
+- production deployment;
+- App Store signing/notarization;
+- raw Registry/database credentials;
+- reusable capability tokens.
+
+The HMAC manifest signature is an Alpha-runner integrity attestation, not Apple code signing. A future release adapter should introduce an asymmetric signing identity or platform signing service before distributing production artifacts.

--- a/docs/apple-runner-governed-build.md
+++ b/docs/apple-runner-governed-build.md
@@ -36,13 +36,15 @@ A separate `ALPHA_ARTIFACT_HMAC_SECRET` signs the artifact manifest. Separating 
 
 The MCP tool accepts no executable, shell expression, package path, output path, build flags or user-defined script. Internally it may run only the fixed sequence:
 
-1. `xcrun swift build -c release --product alpha-metal-artifact`
-2. `xcrun swift test -c release`
-3. `xcrun swift build -c release --show-bin-path`
+1. `xcrun swift build --scratch-path <runner-controlled> -c release --product alpha-metal-artifact`
+2. `xcrun swift test --scratch-path <runner-controlled> -c release`
+3. `xcrun swift build --scratch-path <runner-controlled> -c release --show-bin-path`
 4. the built fixed executable with zero arguments
 5. `sw_vers -productVersion`
 6. `xcodebuild -version`
 7. `xcrun swift --version`
+
+The SwiftPM scratch path is generated inside the adapter's temporary work directory. The binary path returned by SwiftPM is rejected unless it resolves inside that work directory. This keeps compiler/build output within the runner-owned envelope instead of relying on SwiftPM's host defaults.
 
 All child processes use `shell: false`, bounded output and a hard execution timeout.
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,12 @@ import { ZodError } from "zod";
 const program = new Command("algolia-mcp");
 
 const DEFAULT_ALLOW_TOOLS = [
+  // Alpha Node / Newton agentic builder
+  "alphaNewtonListCapabilities",
+  "alphaNewtonPlanMetalWorkload",
+  "alphaNewtonRouteExecutionTarget",
+  "alphaNewtonPlanDevOpsRun",
+  "alphaNewtonCreateAuthorityEnvelope",
   // Dashboard API Tools
   "getUserInfo",
   "getApplications",

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,12 +5,6 @@ import { ZodError } from "zod";
 const program = new Command("algolia-mcp");
 
 const DEFAULT_ALLOW_TOOLS = [
-  // Alpha Node / Newton agentic builder
-  "alphaNewtonListCapabilities",
-  "alphaNewtonPlanMetalWorkload",
-  "alphaNewtonRouteExecutionTarget",
-  "alphaNewtonPlanDevOpsRun",
-  "alphaNewtonCreateAuthorityEnvelope",
   // Dashboard API Tools
   "getUserInfo",
   "getApplications",
@@ -102,6 +96,19 @@ program
     try {
       const { startServer } = await import("./commands/start-server.ts");
       await startServer(opts);
+    } catch (error) {
+      console.error(formatErrorForCli(error));
+      process.exit(1);
+    }
+  });
+
+program
+  .command("start-alpha-newton-server")
+  .description("Starts the Alpha Node / Newton agentic-builder MCP tool surface")
+  .action(async () => {
+    try {
+      const { startAlphaNewtonServer } = await import("./commands/start-alpha-newton-server.ts");
+      await startAlphaNewtonServer();
     } catch (error) {
       console.error(formatErrorForCli(error));
       process.exit(1);

--- a/src/commands/start-alpha-newton-server.ts
+++ b/src/commands/start-alpha-newton-server.ts
@@ -4,14 +4,15 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { CONFIG } from "../config.ts";
 import { CustomMcpServer } from "../CustomMcpServer.ts";
 import { registerAlphaNewtonMetalTools } from "../tools/registerAlphaNewtonMetalTools.ts";
+import { registerAppleRunnerBuild } from "../tools/registerAppleRunnerBuild.ts";
 import { registerAppleRunnerCanary } from "../tools/registerAppleRunnerCanary.ts";
 
 /**
  * Standalone Alpha Node / Newton agentic-builder MCP surface.
  *
- * Planning tools remain provider-neutral. APPLE-RUNNER-001 is the first
- * execution adapter and is intentionally narrow: it runs one fixed Metal
- * canary on macOS only after verifying a Warden-signed, single-use capability.
+ * Planning tools remain provider-neutral. APPLE-RUNNER-001 exposes only
+ * constrained, Warden-gated execution adapters: one deterministic Metal
+ * canary and one fixed Swift/Metal package build/test/artifact workflow.
  */
 export async function startAlphaNewtonServer(): Promise<CustomMcpServer> {
   const server = new CustomMcpServer({
@@ -25,6 +26,7 @@ export async function startAlphaNewtonServer(): Promise<CustomMcpServer> {
 
   registerAlphaNewtonMetalTools(server);
   registerAppleRunnerCanary(server);
+  registerAppleRunnerBuild(server);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/commands/start-alpha-newton-server.ts
+++ b/src/commands/start-alpha-newton-server.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env -S node --experimental-strip-types
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CONFIG } from "../config.ts";
+import { CustomMcpServer } from "../CustomMcpServer.ts";
+import { registerAlphaNewtonMetalTools } from "../tools/registerAlphaNewtonMetalTools.ts";
+
+/**
+ * Standalone Alpha Node / Newton agentic-builder MCP surface.
+ *
+ * This command deliberately does not initialize Algolia credentials or any
+ * deployment provider. The first tool pack is planning-only and returns
+ * pending Warden authority envelopes. Provider-specific execution adapters
+ * can be added behind the same governance boundary later.
+ */
+export async function startAlphaNewtonServer(): Promise<CustomMcpServer> {
+  const server = new CustomMcpServer({
+    name: "alpha-newton",
+    version: CONFIG.version,
+    capabilities: {
+      resources: {},
+      tools: {},
+    },
+  });
+
+  registerAlphaNewtonMetalTools(server);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  return server;
+}

--- a/src/commands/start-alpha-newton-server.ts
+++ b/src/commands/start-alpha-newton-server.ts
@@ -4,14 +4,14 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { CONFIG } from "../config.ts";
 import { CustomMcpServer } from "../CustomMcpServer.ts";
 import { registerAlphaNewtonMetalTools } from "../tools/registerAlphaNewtonMetalTools.ts";
+import { registerAppleRunnerCanary } from "../tools/registerAppleRunnerCanary.ts";
 
 /**
  * Standalone Alpha Node / Newton agentic-builder MCP surface.
  *
- * This command deliberately does not initialize Algolia credentials or any
- * deployment provider. The first tool pack is planning-only and returns
- * pending Warden authority envelopes. Provider-specific execution adapters
- * can be added behind the same governance boundary later.
+ * Planning tools remain provider-neutral. APPLE-RUNNER-001 is the first
+ * execution adapter and is intentionally narrow: it runs one fixed Metal
+ * canary on macOS only after verifying a Warden-signed, single-use capability.
  */
 export async function startAlphaNewtonServer(): Promise<CustomMcpServer> {
   const server = new CustomMcpServer({
@@ -24,6 +24,7 @@ export async function startAlphaNewtonServer(): Promise<CustomMcpServer> {
   });
 
   registerAlphaNewtonMetalTools(server);
+  registerAppleRunnerCanary(server);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/tools/registerAlphaNewtonMetalTools.test.ts
+++ b/src/tools/registerAlphaNewtonMetalTools.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { CustomMcpServer } from "../CustomMcpServer.ts";
+import {
+  AlphaNewtonOperationIds,
+  registerAlphaNewtonMetalTools,
+} from "./registerAlphaNewtonMetalTools.ts";
+
+type CapturedTool = {
+  name: string;
+  cb: (...args: unknown[]) => string | Promise<string>;
+};
+
+function captureTools(): CapturedTool[] {
+  const tools: CapturedTool[] = [];
+  const server = {
+    tool(definition: CapturedTool) {
+      tools.push(definition);
+    },
+  } as unknown as CustomMcpServer;
+
+  registerAlphaNewtonMetalTools(server);
+  return tools;
+}
+
+describe("Alpha Newton tool pack", () => {
+  it("registers the five first-slice tools", () => {
+    const tools = captureTools();
+    expect(tools.map((tool) => tool.name)).toEqual([
+      AlphaNewtonOperationIds.listCapabilities,
+      AlphaNewtonOperationIds.planMetalWorkload,
+      AlphaNewtonOperationIds.routeExecutionTarget,
+      AlphaNewtonOperationIds.planDevOpsRun,
+      AlphaNewtonOperationIds.createAuthorityEnvelope,
+    ]);
+  });
+
+  it("routes Metal work on Linux to a remote Apple runner", async () => {
+    const routeTool = captureTools().find(
+      (tool) => tool.name === AlphaNewtonOperationIds.routeExecutionTarget,
+    );
+    expect(routeTool).toBeDefined();
+
+    const result = JSON.parse(
+      await routeTool!.cb({
+        workloadClass: "compute",
+        requiresMetal: true,
+        localHostClass: "linux",
+      }),
+    );
+
+    expect(result.route).toBe("CONTROL_PLANE_TO_REMOTE_APPLE_RUNNER");
+    expect(result.localMetalCapable).toBe(false);
+    expect(result.executionAllowed).toBe(false);
+  });
+
+  it("keeps authority envelopes pending until Warden authorization", async () => {
+    const envelopeTool = captureTools().find(
+      (tool) => tool.name === AlphaNewtonOperationIds.createAuthorityEnvelope,
+    );
+    expect(envelopeTool).toBeDefined();
+
+    const result = JSON.parse(
+      await envelopeTool!.cb({
+        digitalMeId: "DM-TEST-001",
+        authorityRef: "AUTH-TEST-001",
+        workspaceRef: "ALPHA-NODE-001",
+        intent: "compile synthetic Metal fixture",
+        requestedTool: "apple-runner-build",
+      }),
+    );
+
+    expect(result.status).toBe("PENDING_WARDEN_AUTHORIZATION");
+    expect(result.executionAllowed).toBe(false);
+    expect(result.principal).toBe("DM-TEST-001");
+  });
+});

--- a/src/tools/registerAlphaNewtonMetalTools.ts
+++ b/src/tools/registerAlphaNewtonMetalTools.ts
@@ -1,0 +1,368 @@
+import type { CustomMcpServer } from "../CustomMcpServer.ts";
+
+export const AlphaNewtonOperationIds = {
+  listCapabilities: "alphaNewtonListCapabilities",
+  planMetalWorkload: "alphaNewtonPlanMetalWorkload",
+  routeExecutionTarget: "alphaNewtonRouteExecutionTarget",
+  planDevOpsRun: "alphaNewtonPlanDevOpsRun",
+  createAuthorityEnvelope: "alphaNewtonCreateAuthorityEnvelope",
+} as const;
+
+const METAL_CAPABILITIES = {
+  compute: {
+    frameworks: ["Metal compute passes", "Metal Performance Shaders"],
+    useFor: ["parallel numerical kernels", "buffer/texture transforms", "GPU preprocessing"],
+  },
+  imageProcessing: {
+    frameworks: ["Metal Performance Shaders"],
+    useFor: ["filters", "histograms/statistics", "optimized image kernels"],
+  },
+  tensorGraph: {
+    frameworks: ["Metal Performance Shaders Graph"],
+    useFor: ["tensor graphs", "ML inference", "ML training", "FFT/convolution workflows"],
+  },
+  rayTracing: {
+    frameworks: ["Metal ray tracing", "Metal compute passes"],
+    useFor: ["intersection queries", "reflections", "ray-traced rendering"],
+  },
+  rendering: {
+    frameworks: ["Metal rendering", "MetalFX"],
+    useFor: ["render pipelines", "temporal/spatial upscaling", "GPU frame generation"],
+  },
+  resources: {
+    frameworks: ["Metal resource management"],
+    useFor: ["buffers", "textures", "heaps", "argument buffers", "resource synchronization"],
+  },
+} as const;
+
+const GOVERNED_SEQUENCE = [
+  "IDENTIFY",
+  "RELATE",
+  "AUTHORIZE",
+  "PROVISION",
+  "ACT",
+  "OBSERVE",
+  "EVIDENCE",
+  "EFFECT",
+  "SETTLE",
+  "CLOSE_OR_SUPERSEDE",
+] as const;
+
+function makePendingAuthorityEnvelope(input: {
+  digitalMeId: string;
+  authorityRef: string;
+  workspaceRef: string;
+  intent: string;
+  requestedTool?: string;
+  evidenceRefs?: string[];
+  expiresAt?: string;
+}) {
+  return {
+    schema: "ALPHA-NEWTON-AUTHORITY-ENVELOPE-001",
+    status: "PENDING_WARDEN_AUTHORIZATION",
+    executionAllowed: false,
+    principal: input.digitalMeId,
+    authorityRef: input.authorityRef,
+    workspaceRef: input.workspaceRef,
+    intent: input.intent,
+    requestedTool: input.requestedTool ?? null,
+    evidenceRefs: input.evidenceRefs ?? [],
+    expiresAt: input.expiresAt ?? null,
+    invariants: [
+      "ENTITY != AGENT != LLM != AUTHORITY",
+      "recommendation != authorization",
+      "no secrets in tool arguments or evidence payloads",
+      "execution requires a Warden-issued capability envelope",
+    ],
+  };
+}
+
+function workloadFrameworks(workloadClass: string): string[] {
+  switch (workloadClass) {
+    case "compute":
+      return [...METAL_CAPABILITIES.compute.frameworks];
+    case "image-processing":
+      return [...METAL_CAPABILITIES.imageProcessing.frameworks];
+    case "tensor-graph":
+    case "ml-inference":
+    case "ml-training":
+      return [...METAL_CAPABILITIES.tensorGraph.frameworks];
+    case "ray-tracing":
+      return [...METAL_CAPABILITIES.rayTracing.frameworks];
+    case "render":
+      return [...METAL_CAPABILITIES.rendering.frameworks];
+    case "resource-management":
+      return [...METAL_CAPABILITIES.resources.frameworks];
+    default:
+      return [];
+  }
+}
+
+export function registerAlphaNewtonMetalTools(server: CustomMcpServer) {
+  server.tool({
+    name: AlphaNewtonOperationIds.listCapabilities,
+    description:
+      "List the Alpha Node Newton agentic-builder tool surface for Apple Metal/MPS acceleration and governed DevOps planning.",
+    annotations: { readOnlyHint: true },
+    inputSchema: undefined,
+    cb: async () =>
+      JSON.stringify({
+        toolPack: "ALPHA-NEWTON-METAL-TOOLS-001",
+        role: "governed planning and capability surface; not an execution authority",
+        capabilities: METAL_CAPABILITIES,
+        executionBoundary: {
+          appleMetalRuntime: "requires an Apple platform/runner with Metal support",
+          nonAppleControlPlane:
+            "may plan, generate manifests, review evidence, and orchestrate remote Apple runners but cannot execute Metal locally",
+        },
+      }),
+  });
+
+  server.tool({
+    name: AlphaNewtonOperationIds.planMetalWorkload,
+    description:
+      "Plan a Metal/MPS workload and return framework choices, build stages, evidence requirements, and acceptance checks without executing code.",
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        workloadClass: {
+          type: "string",
+          enum: [
+            "compute",
+            "image-processing",
+            "tensor-graph",
+            "ml-inference",
+            "ml-training",
+            "ray-tracing",
+            "render",
+            "resource-management",
+          ],
+        },
+        objective: { type: "string", minLength: 1 },
+        targetPlatform: {
+          type: "string",
+          enum: ["macOS", "iOS", "iPadOS", "visionOS", "unspecified-apple"],
+        },
+        targetDevice: { type: "string" },
+        latencyTargetMs: { type: "number", minimum: 0 },
+        memoryBudgetMb: { type: "number", minimum: 1 },
+        notes: { type: "string" },
+      },
+      required: ["workloadClass", "objective", "targetPlatform"],
+    },
+    cb: async (args) => {
+      const input = args as {
+        workloadClass: string;
+        objective: string;
+        targetPlatform: string;
+        targetDevice?: string;
+        latencyTargetMs?: number;
+        memoryBudgetMb?: number;
+        notes?: string;
+      };
+      const frameworks = workloadFrameworks(input.workloadClass);
+
+      return JSON.stringify({
+        schema: "ALPHA-NEWTON-METAL-PLAN-001",
+        objective: input.objective,
+        workloadClass: input.workloadClass,
+        target: {
+          platform: input.targetPlatform,
+          device: input.targetDevice ?? "resolve-at-build-time",
+        },
+        frameworkCandidates: frameworks,
+        pipeline: [
+          "resolve Apple runner and SDK/Xcode compatibility",
+          "define buffers/textures/tensors and data ownership",
+          "select framework primitive before writing custom shader code",
+          "compile/build with warnings treated as evidence",
+          "run deterministic synthetic fixture",
+          "capture CPU/GPU timing, memory, and correctness evidence",
+          "compare against acceptance thresholds",
+          "publish immutable build/evidence references",
+        ],
+        constraints: {
+          latencyTargetMs: input.latencyTargetMs ?? null,
+          memoryBudgetMb: input.memoryBudgetMb ?? null,
+          notes: input.notes ?? null,
+        },
+        acceptanceChecks: [
+          "build succeeds on the declared Apple target",
+          "same fixture produces expected numerical or pixel output",
+          "no unauthorized fallback path changes semantics",
+          "resource lifetime and synchronization are explicit",
+          "performance measurements include device, OS, SDK, and build identity",
+        ],
+        executionAllowed: false,
+        nextGate: "WARDEN_AUTHORIZATION_FOR_BUILD_OR_RUN",
+      });
+    },
+  });
+
+  server.tool({
+    name: AlphaNewtonOperationIds.routeExecutionTarget,
+    description:
+      "Route a requested workload between the Alpha control plane and an Apple execution runner. This is a routing decision only; it does not start a runner.",
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        workloadClass: { type: "string", minLength: 1 },
+        requiresMetal: { type: "boolean" },
+        localHostClass: {
+          type: "string",
+          enum: ["apple-silicon", "intel-mac", "linux", "windows", "unknown"],
+        },
+        preferredRunnerRef: { type: "string" },
+      },
+      required: ["workloadClass", "requiresMetal", "localHostClass"],
+    },
+    cb: async (args) => {
+      const input = args as {
+        workloadClass: string;
+        requiresMetal: boolean;
+        localHostClass: string;
+        preferredRunnerRef?: string;
+      };
+      const localCanRunMetal =
+        input.localHostClass === "apple-silicon" || input.localHostClass === "intel-mac";
+      const needsRemoteAppleRunner = input.requiresMetal && !localCanRunMetal;
+
+      return JSON.stringify({
+        schema: "ALPHA-NEWTON-EXECUTION-ROUTE-001",
+        workloadClass: input.workloadClass,
+        route: needsRemoteAppleRunner
+          ? "CONTROL_PLANE_TO_REMOTE_APPLE_RUNNER"
+          : "LOCAL_OR_DECLARED_RUNNER",
+        preferredRunnerRef: input.preferredRunnerRef ?? null,
+        localMetalCapable: localCanRunMetal,
+        requiresRemoteAppleRunner: needsRemoteAppleRunner,
+        executionAllowed: false,
+        nextGate: "RESOLVE_RUNNER_IDENTITY_AND_WARDEN_CAPABILITY",
+      });
+    },
+  });
+
+  server.tool({
+    name: AlphaNewtonOperationIds.planDevOpsRun,
+    description:
+      "Create a governed DevOps run plan for an agentic builder, including authority, test, evidence, release and rollback gates. No repository or deployment changes are performed.",
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        repository: { type: "string", minLength: 1 },
+        ref: { type: "string", minLength: 1 },
+        goal: { type: "string", minLength: 1 },
+        targetEnvironment: {
+          type: "string",
+          enum: ["local", "dev", "test", "staging", "production"],
+        },
+        changeClass: {
+          type: "string",
+          enum: ["docs", "code", "schema", "infra", "security", "release"],
+        },
+        requestedTools: { type: "array", items: { type: "string" } },
+        digitalMeId: { type: "string", minLength: 1 },
+        authorityRef: { type: "string", minLength: 1 },
+        workspaceRef: { type: "string", minLength: 1 },
+      },
+      required: [
+        "repository",
+        "ref",
+        "goal",
+        "targetEnvironment",
+        "changeClass",
+        "digitalMeId",
+        "authorityRef",
+        "workspaceRef",
+      ],
+    },
+    cb: async (args) => {
+      const input = args as {
+        repository: string;
+        ref: string;
+        goal: string;
+        targetEnvironment: string;
+        changeClass: string;
+        requestedTools?: string[];
+        digitalMeId: string;
+        authorityRef: string;
+        workspaceRef: string;
+      };
+
+      const production = input.targetEnvironment === "production";
+      return JSON.stringify({
+        schema: "ALPHA-NEWTON-DEVOPS-RUN-001",
+        repository: input.repository,
+        ref: input.ref,
+        goal: input.goal,
+        targetEnvironment: input.targetEnvironment,
+        changeClass: input.changeClass,
+        requestedTools: input.requestedTools ?? [],
+        governedSequence: GOVERNED_SEQUENCE,
+        authorityEnvelope: makePendingAuthorityEnvelope({
+          digitalMeId: input.digitalMeId,
+          authorityRef: input.authorityRef,
+          workspaceRef: input.workspaceRef,
+          intent: input.goal,
+        }),
+        stages: [
+          { id: "preflight", checks: ["repo/ref resolves", "working tree or change set identified"] },
+          { id: "authority", checks: ["principal resolved", "capability scope covers requested tools"] },
+          { id: "build", checks: ["dependencies pinned", "build reproducible"] },
+          { id: "test", checks: ["unit/static tests", "smallest synthetic workflow"] },
+          { id: "evidence", checks: ["logs/artifacts hashed", "test and build identity recorded"] },
+          {
+            id: "release",
+            checks: production
+              ? ["explicit production authorization", "rollback target captured", "post-release verification"]
+              : ["environment-scoped authorization", "post-run verification"],
+          },
+          { id: "close", checks: ["effect recorded", "exceptions resolved or carried forward"] },
+        ],
+        executionAllowed: false,
+        nextGate: "WARDEN_AUTHORIZATION_FOR_CHANGESET",
+      });
+    },
+  });
+
+  server.tool({
+    name: AlphaNewtonOperationIds.createAuthorityEnvelope,
+    description:
+      "Create a non-executing authority request envelope for a Newton/Alpha tool invocation. The envelope remains pending until Warden issues the actual capability.",
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        digitalMeId: { type: "string", minLength: 1 },
+        authorityRef: { type: "string", minLength: 1 },
+        workspaceRef: { type: "string", minLength: 1 },
+        intent: { type: "string", minLength: 1 },
+        requestedTool: { type: "string", minLength: 1 },
+        evidenceRefs: { type: "array", items: { type: "string" } },
+        expiresAt: { type: "string" },
+      },
+      required: ["digitalMeId", "authorityRef", "workspaceRef", "intent", "requestedTool"],
+    },
+    cb: async (args) =>
+      JSON.stringify(
+        makePendingAuthorityEnvelope(
+          args as {
+            digitalMeId: string;
+            authorityRef: string;
+            workspaceRef: string;
+            intent: string;
+            requestedTool: string;
+            evidenceRefs?: string[];
+            expiresAt?: string;
+          },
+        ),
+      ),
+  });
+}

--- a/src/tools/registerAppleRunnerBuild.test.ts
+++ b/src/tools/registerAppleRunnerBuild.test.ts
@@ -1,0 +1,175 @@
+import { createHmac, randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CustomMcpServer } from "../CustomMcpServer.ts";
+import {
+  AppleRunnerBuildOperationId,
+  registerAppleRunnerBuild,
+  type AppleBuildWardenCapabilityPayload,
+} from "./registerAppleRunnerBuild.ts";
+
+type CapturedTool = {
+  name: string;
+  cb: (...args: unknown[]) => string | Promise<string>;
+};
+
+function captureTool(): CapturedTool {
+  const tools: CapturedTool[] = [];
+  const server = {
+    tool(definition: CapturedTool) {
+      tools.push(definition);
+    },
+  } as unknown as CustomMcpServer;
+
+  registerAppleRunnerBuild(server);
+  expect(tools).toHaveLength(1);
+  return tools[0]!;
+}
+
+function makeToken(
+  secret: string,
+  overrides: Partial<AppleBuildWardenCapabilityPayload> = {},
+): string {
+  const now = Date.now();
+  const payload: AppleBuildWardenCapabilityPayload = {
+    schema: "ALPHA-WARDEN-CAPABILITY-001",
+    issuedBy: "WARDEN",
+    status: "AUTHORIZED",
+    capabilityId: `CAP-BUILD-${randomUUID()}`,
+    principal: "DM-TEST-001",
+    workspaceRef: "ALPHA-NODE-001",
+    tool: AppleRunnerBuildOperationId,
+    runnerRef: "APPLE-RUNNER-001",
+    scopes: ["APPLE-RUNNER-001:SWIFT-BUILD"],
+    nonce: `NONCE-${randomUUID()}`,
+    issuedAt: new Date(now - 1_000).toISOString(),
+    expiresAt: new Date(now + 120_000).toISOString(),
+    ...overrides,
+  };
+  const payloadPart = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  const signature = createHmac("sha256", secret).update(payloadPart).digest("base64url");
+  return `${payloadPart}.${signature}`;
+}
+
+const originalWardenSecret = process.env.ALPHA_WARDEN_HMAC_SECRET;
+const originalArtifactSecret = process.env.ALPHA_ARTIFACT_HMAC_SECRET;
+const originalReplayDir = process.env.ALPHA_WARDEN_REPLAY_DIR;
+const originalArtifactDir = process.env.ALPHA_APPLE_ARTIFACT_DIR;
+
+let replayDir: string | undefined;
+let artifactDir: string | undefined;
+
+beforeEach(async () => {
+  replayDir = await mkdtemp(join(tmpdir(), "alpha-build-replay-test-"));
+  artifactDir = await mkdtemp(join(tmpdir(), "alpha-build-artifact-test-"));
+  process.env.ALPHA_WARDEN_HMAC_SECRET = "test-only-warden-secret";
+  process.env.ALPHA_ARTIFACT_HMAC_SECRET = "test-only-artifact-secret";
+  process.env.ALPHA_WARDEN_REPLAY_DIR = replayDir;
+  process.env.ALPHA_APPLE_ARTIFACT_DIR = artifactDir;
+});
+
+afterEach(async () => {
+  if (replayDir) {
+    await rm(replayDir, { recursive: true, force: true });
+  }
+  if (artifactDir) {
+    await rm(artifactDir, { recursive: true, force: true });
+  }
+
+  if (originalWardenSecret === undefined) delete process.env.ALPHA_WARDEN_HMAC_SECRET;
+  else process.env.ALPHA_WARDEN_HMAC_SECRET = originalWardenSecret;
+
+  if (originalArtifactSecret === undefined) delete process.env.ALPHA_ARTIFACT_HMAC_SECRET;
+  else process.env.ALPHA_ARTIFACT_HMAC_SECRET = originalArtifactSecret;
+
+  if (originalReplayDir === undefined) delete process.env.ALPHA_WARDEN_REPLAY_DIR;
+  else process.env.ALPHA_WARDEN_REPLAY_DIR = originalReplayDir;
+
+  if (originalArtifactDir === undefined) delete process.env.ALPHA_APPLE_ARTIFACT_DIR;
+  else process.env.ALPHA_APPLE_ARTIFACT_DIR = originalArtifactDir;
+});
+
+describe("APPLE-RUNNER-001 governed build adapter", () => {
+  it("registers exactly one fixed build tool", () => {
+    expect(captureTool().name).toBe(AppleRunnerBuildOperationId);
+  });
+
+  it("refuses execution when Warden verification is not configured", async () => {
+    delete process.env.ALPHA_WARDEN_HMAC_SECRET;
+    const tool = captureTool();
+
+    await expect(
+      tool.cb({
+        runnerRef: "APPLE-RUNNER-001",
+        fixture: "metal-vector-add-package-v1",
+        capabilityToken: "not-a-real-token",
+      }),
+    ).rejects.toThrow("WARDEN_AUTHORITY_VERIFIER_NOT_CONFIGURED");
+  });
+
+  it("refuses to build without a separate artifact signer", async () => {
+    const wardenSecret = process.env.ALPHA_WARDEN_HMAC_SECRET!;
+    delete process.env.ALPHA_ARTIFACT_HMAC_SECRET;
+    const tool = captureTool();
+
+    await expect(
+      tool.cb({
+        runnerRef: "APPLE-RUNNER-001",
+        fixture: "metal-vector-add-package-v1",
+        capabilityToken: makeToken(wardenSecret),
+      }),
+    ).rejects.toThrow("ARTIFACT_SIGNER_NOT_CONFIGURED");
+  });
+
+  it("rejects authority issued for another build runner", async () => {
+    const wardenSecret = process.env.ALPHA_WARDEN_HMAC_SECRET!;
+    const tool = captureTool();
+
+    await expect(
+      tool.cb({
+        runnerRef: "APPLE-RUNNER-001",
+        fixture: "metal-vector-add-package-v1",
+        capabilityToken: makeToken(wardenSecret, { runnerRef: "APPLE-RUNNER-999" }),
+      }),
+    ).rejects.toThrow("WARDEN_CAPABILITY_RUNNER_MISMATCH");
+  });
+
+  it(
+    "builds, tests, verifies and signs the fixed Swift/Metal artifact on macOS",
+    async () => {
+      const wardenSecret = process.env.ALPHA_WARDEN_HMAC_SECRET!;
+      const tool = captureTool();
+      const input = {
+        runnerRef: "APPLE-RUNNER-001",
+        fixture: "metal-vector-add-package-v1",
+        capabilityToken: makeToken(wardenSecret),
+      };
+
+      if (process.platform !== "darwin") {
+        await expect(tool.cb(input)).rejects.toThrow("APPLE_RUNNER_REQUIRES_MACOS");
+        return;
+      }
+
+      const result = JSON.parse(await tool.cb(input));
+      expect(result.schema).toBe("APPLE-RUNNER-BUILD-EXECUTION-001");
+      expect(result.executionPolicy.arbitraryCommandExecution).toBe(false);
+      expect(result.manifest.schema).toBe("APPLE-RUNNER-ARTIFACT-MANIFEST-001");
+      expect(result.manifest.fixture).toBe("metal-vector-add-package-v1");
+      expect(result.manifest.artifact.sha256).toMatch(/^[a-f0-9]{64}$/);
+      expect(result.manifest.artifact.sizeBytes).toBeGreaterThan(0);
+      expect(result.manifest.verification.testsPassed).toBe(true);
+      expect(result.manifest.verification.artifactSelfTestPassed).toBe(true);
+      expect(result.manifest.verification.evidence.output).toEqual([11, 22, 33, 44]);
+      expect(result.manifest.verification.evidence.correct).toBe(true);
+      expect(result.manifestSignature.algorithm).toBe("HMAC-SHA256");
+      expect(result.manifestSignature.value).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(result.storage.artifactRef).toMatch(
+        /^apple-runner:\/\/APPLE-RUNNER-001\/[a-f0-9]{24}\/alpha-metal-artifact$/,
+      );
+      expect(result.storage.durableStorageConfigured).toBe(true);
+    },
+    180_000,
+  );
+});

--- a/src/tools/registerAppleRunnerBuild.ts
+++ b/src/tools/registerAppleRunnerBuild.ts
@@ -421,28 +421,46 @@ export function registerAppleRunnerBuild(server: CustomMcpServer) {
       const workDir = await mkdtemp(join(tmpdir(), "alpha-apple-build-"));
       try {
         const sourceSha256 = await writeFixedPackage(workDir);
+        const scratchDir = join(workDir, ".alpha-build");
         const build = await requireSuccessful(
           "APPLE_SWIFT_BUILD",
           "xcrun",
-          ["swift", "build", "-c", "release", "--product", PRODUCT_NAME],
+          [
+            "swift",
+            "build",
+            "--scratch-path",
+            scratchDir,
+            "-c",
+            "release",
+            "--product",
+            PRODUCT_NAME,
+          ],
           workDir,
         );
         const tests = await requireSuccessful(
           "APPLE_SWIFT_TEST",
           "xcrun",
-          ["swift", "test", "-c", "release"],
+          ["swift", "test", "--scratch-path", scratchDir, "-c", "release"],
           workDir,
         );
         const binPathResult = await requireSuccessful(
           "APPLE_SWIFT_BIN_PATH",
           "xcrun",
-          ["swift", "build", "-c", "release", "--show-bin-path"],
+          ["swift", "build", "--scratch-path", scratchDir, "-c", "release", "--show-bin-path"],
           workDir,
         );
 
-        const binRoot = resolve(binPathResult.stdout);
+        const binPathLine = binPathResult.stdout
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .filter(Boolean)
+          .at(-1);
+        if (!binPathLine) {
+          throw new Error("APPLE_BUILD_BIN_PATH_EMPTY");
+        }
+        const binRoot = resolve(workDir, binPathLine);
         const resolvedWorkDir = resolve(workDir);
-        if (!binRoot.startsWith(`${resolvedWorkDir}${sep}`)) {
+        if (binRoot !== resolvedWorkDir && !binRoot.startsWith(`${resolvedWorkDir}${sep}`)) {
           throw new Error("APPLE_BUILD_BIN_PATH_OUTSIDE_WORKDIR");
         }
         const executablePath = join(binRoot, PRODUCT_NAME);
@@ -547,9 +565,9 @@ export function registerAppleRunnerBuild(server: CustomMcpServer) {
             shell: false,
             arbitraryCommandExecution: false,
             allowedCommands: [
-              "xcrun swift build -c release --product alpha-metal-artifact",
-              "xcrun swift test -c release",
-              "xcrun swift build -c release --show-bin-path",
+              "xcrun swift build --scratch-path <runner-controlled> -c release --product alpha-metal-artifact",
+              "xcrun swift test --scratch-path <runner-controlled> -c release",
+              "xcrun swift build --scratch-path <runner-controlled> -c release --show-bin-path",
               "<built-fixed-artifact>",
               "sw_vers -productVersion",
               "xcodebuild -version",

--- a/src/tools/registerAppleRunnerBuild.ts
+++ b/src/tools/registerAppleRunnerBuild.ts
@@ -1,0 +1,574 @@
+import { spawn } from "node:child_process";
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve, sep } from "node:path";
+import type { CustomMcpServer } from "../CustomMcpServer.ts";
+
+export const AppleRunnerBuildOperationId = "appleRunnerBuildSwiftArtifact";
+const REQUIRED_SCOPE = "APPLE-RUNNER-001:SWIFT-BUILD";
+const FIXTURE_ID = "metal-vector-add-package-v1";
+const PRODUCT_NAME = "alpha-metal-artifact";
+const MAX_OUTPUT_BYTES = 256 * 1024;
+const EXECUTION_TIMEOUT_MS = 180_000;
+
+export type AppleBuildWardenCapabilityPayload = {
+  schema: "ALPHA-WARDEN-CAPABILITY-001";
+  issuedBy: "WARDEN";
+  status: "AUTHORIZED";
+  capabilityId: string;
+  principal: string;
+  workspaceRef: string;
+  tool: typeof AppleRunnerBuildOperationId;
+  runnerRef: string;
+  scopes: string[];
+  nonce: string;
+  issuedAt: string;
+  expiresAt: string;
+};
+
+type CommandResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};
+
+function decodeBase64Url(value: string): Buffer {
+  return Buffer.from(value, "base64url");
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function verifyWardenCapability(
+  token: string,
+  runnerRef: string,
+): AppleBuildWardenCapabilityPayload {
+  const secret = process.env.ALPHA_WARDEN_HMAC_SECRET;
+  if (!secret) {
+    throw new Error("WARDEN_AUTHORITY_VERIFIER_NOT_CONFIGURED");
+  }
+
+  const [payloadPart, signaturePart, ...extra] = token.split(".");
+  if (!payloadPart || !signaturePart || extra.length) {
+    throw new Error("INVALID_WARDEN_CAPABILITY_TOKEN");
+  }
+
+  const expectedSignature = createHmac("sha256", secret).update(payloadPart).digest();
+  const actualSignature = decodeBase64Url(signaturePart);
+  if (
+    actualSignature.length !== expectedSignature.length ||
+    !timingSafeEqual(actualSignature, expectedSignature)
+  ) {
+    throw new Error("INVALID_WARDEN_CAPABILITY_SIGNATURE");
+  }
+
+  let payload: AppleBuildWardenCapabilityPayload;
+  try {
+    payload = JSON.parse(
+      decodeBase64Url(payloadPart).toString("utf8"),
+    ) as AppleBuildWardenCapabilityPayload;
+  } catch {
+    throw new Error("INVALID_WARDEN_CAPABILITY_PAYLOAD");
+  }
+
+  if (
+    payload.schema !== "ALPHA-WARDEN-CAPABILITY-001" ||
+    payload.issuedBy !== "WARDEN" ||
+    payload.status !== "AUTHORIZED"
+  ) {
+    throw new Error("WARDEN_CAPABILITY_NOT_AUTHORIZED");
+  }
+  if (payload.tool !== AppleRunnerBuildOperationId) {
+    throw new Error("WARDEN_CAPABILITY_TOOL_MISMATCH");
+  }
+  if (payload.runnerRef !== runnerRef) {
+    throw new Error("WARDEN_CAPABILITY_RUNNER_MISMATCH");
+  }
+  if (!payload.scopes?.includes(REQUIRED_SCOPE)) {
+    throw new Error("WARDEN_CAPABILITY_SCOPE_MISSING");
+  }
+  if (!payload.capabilityId || !payload.principal || !payload.workspaceRef || !payload.nonce) {
+    throw new Error("WARDEN_CAPABILITY_CONTEXT_INCOMPLETE");
+  }
+
+  const issuedAt = Date.parse(payload.issuedAt);
+  const expiresAt = Date.parse(payload.expiresAt);
+  const now = Date.now();
+  if (!Number.isFinite(issuedAt) || !Number.isFinite(expiresAt) || issuedAt > now + 60_000) {
+    throw new Error("WARDEN_CAPABILITY_TIME_INVALID");
+  }
+  if (expiresAt <= now) {
+    throw new Error("WARDEN_CAPABILITY_EXPIRED");
+  }
+
+  return payload;
+}
+
+async function consumeReplayNonce(payload: AppleBuildWardenCapabilityPayload): Promise<void> {
+  const replayRoot = process.env.ALPHA_WARDEN_REPLAY_DIR ?? join(tmpdir(), "alpha-newton-replay");
+  await mkdir(replayRoot, { recursive: true });
+  const markerId = sha256(`${payload.capabilityId}\0${payload.nonce}`);
+  const marker = join(replayRoot, `${markerId}.used`);
+
+  try {
+    await writeFile(
+      marker,
+      JSON.stringify({
+        capabilityId: payload.capabilityId,
+        nonce: payload.nonce,
+        usedAt: new Date().toISOString(),
+      }),
+      { flag: "wx", mode: 0o600 },
+    );
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "EEXIST") {
+      throw new Error("WARDEN_CAPABILITY_REPLAY_DETECTED");
+    }
+    throw error;
+  }
+}
+
+function runFixedCommand(command: string, args: string[], cwd: string): Promise<CommandResult> {
+  return new Promise((resolveResult, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: { ...process.env },
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = Buffer.alloc(0);
+    let stderr = Buffer.alloc(0);
+    let killedForOutput = false;
+    let timedOut = false;
+
+    const append = (current: Buffer, chunk: Buffer): Buffer => {
+      const next = Buffer.concat([current, chunk]);
+      if (next.length > MAX_OUTPUT_BYTES) {
+        killedForOutput = true;
+        child.kill("SIGKILL");
+        return next.subarray(0, MAX_OUTPUT_BYTES);
+      }
+      return next;
+    };
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout = append(stdout, chunk);
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr = append(stderr, chunk);
+    });
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, EXECUTION_TIMEOUT_MS);
+
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      if (killedForOutput) {
+        reject(new Error("APPLE_RUNNER_OUTPUT_LIMIT_EXCEEDED"));
+        return;
+      }
+      if (timedOut) {
+        reject(new Error("APPLE_RUNNER_BUILD_TIMEOUT"));
+        return;
+      }
+      resolveResult({
+        stdout: stdout.toString("utf8").trim(),
+        stderr: stderr.toString("utf8").trim(),
+        exitCode: code ?? -1,
+      });
+    });
+  });
+}
+
+const PACKAGE_SWIFT = `// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "AlphaMetalArtifact",
+    platforms: [.macOS(.v15)],
+    products: [
+        .library(name: "AlphaMetalCore", targets: ["AlphaMetalCore"]),
+        .executable(name: "${PRODUCT_NAME}", targets: ["AlphaMetalArtifact"]),
+    ],
+    targets: [
+        .target(name: "AlphaMetalCore"),
+        .executableTarget(name: "AlphaMetalArtifact", dependencies: ["AlphaMetalCore"]),
+        .testTarget(name: "AlphaMetalCoreTests", dependencies: ["AlphaMetalCore"]),
+    ]
+)
+`;
+
+const CORE_SWIFT = String.raw`import Foundation
+import Metal
+
+public struct AlphaMetalEvidence: Codable, Sendable {
+    public let schema: String
+    public let fixture: String
+    public let deviceName: String
+    public let registryID: UInt64
+    public let unifiedMemory: Bool
+    public let output: [Float]
+    public let expected: [Float]
+    public let correct: Bool
+    public let cpuElapsedMs: Double
+    public let gpuElapsedMs: Double?
+}
+
+public enum AlphaMetalFailure: Error {
+    case deviceUnavailable
+    case commandQueueUnavailable
+    case functionUnavailable
+    case resourceAllocationFailed
+    case commandFailed(String)
+}
+
+public func runMetalVectorAdd() throws -> AlphaMetalEvidence {
+    guard let device = MTLCreateSystemDefaultDevice() else {
+        throw AlphaMetalFailure.deviceUnavailable
+    }
+    guard let queue = device.makeCommandQueue() else {
+        throw AlphaMetalFailure.commandQueueUnavailable
+    }
+
+    let source = """
+    #include <metal_stdlib>
+    using namespace metal;
+    kernel void vector_add(const device float* a [[buffer(0)]],
+                           const device float* b [[buffer(1)]],
+                           device float* out [[buffer(2)]],
+                           uint id [[thread_position_in_grid]]) {
+        out[id] = a[id] + b[id];
+    }
+    """
+
+    let library = try device.makeLibrary(source: source, options: nil)
+    guard let function = library.makeFunction(name: "vector_add") else {
+        throw AlphaMetalFailure.functionUnavailable
+    }
+    let pipeline = try device.makeComputePipelineState(function: function)
+
+    let a: [Float] = [1, 2, 3, 4]
+    let b: [Float] = [10, 20, 30, 40]
+    let expected: [Float] = [11, 22, 33, 44]
+    let byteCount = a.count * MemoryLayout<Float>.stride
+
+    guard let aBuffer = device.makeBuffer(bytes: a, length: byteCount),
+          let bBuffer = device.makeBuffer(bytes: b, length: byteCount),
+          let outBuffer = device.makeBuffer(length: byteCount),
+          let commandBuffer = queue.makeCommandBuffer(),
+          let encoder = commandBuffer.makeComputeCommandEncoder() else {
+        throw AlphaMetalFailure.resourceAllocationFailed
+    }
+
+    encoder.setComputePipelineState(pipeline)
+    encoder.setBuffer(aBuffer, offset: 0, index: 0)
+    encoder.setBuffer(bBuffer, offset: 0, index: 1)
+    encoder.setBuffer(outBuffer, offset: 0, index: 2)
+    let width = min(pipeline.maxTotalThreadsPerThreadgroup, a.count)
+    encoder.dispatchThreads(
+        MTLSize(width: a.count, height: 1, depth: 1),
+        threadsPerThreadgroup: MTLSize(width: width, height: 1, depth: 1)
+    )
+    encoder.endEncoding()
+
+    let start = DispatchTime.now().uptimeNanoseconds
+    commandBuffer.commit()
+    commandBuffer.waitUntilCompleted()
+    let end = DispatchTime.now().uptimeNanoseconds
+
+    guard commandBuffer.status == .completed else {
+        throw AlphaMetalFailure.commandFailed(String(describing: commandBuffer.error))
+    }
+
+    let values = outBuffer.contents().bindMemory(to: Float.self, capacity: a.count)
+    let output = Array(UnsafeBufferPointer(start: values, count: a.count))
+    let gpuElapsed = commandBuffer.gpuEndTime > commandBuffer.gpuStartTime
+        ? (commandBuffer.gpuEndTime - commandBuffer.gpuStartTime) * 1000.0
+        : nil
+
+    return AlphaMetalEvidence(
+        schema: "APPLE-RUNNER-METAL-ARTIFACT-EVIDENCE-001",
+        fixture: "metal-vector-add-package-v1",
+        deviceName: device.name,
+        registryID: device.registryID,
+        unifiedMemory: device.hasUnifiedMemory,
+        output: output,
+        expected: expected,
+        correct: output == expected,
+        cpuElapsedMs: Double(end - start) / 1_000_000.0,
+        gpuElapsedMs: gpuElapsed
+    )
+}
+`;
+
+const MAIN_SWIFT = String.raw`import Foundation
+import AlphaMetalCore
+
+func fail(_ message: String, code: Int32) -> Never {
+    fputs(message + "\n", stderr)
+    exit(code)
+}
+
+do {
+    let evidence = try runMetalVectorAdd()
+    let data = try JSONEncoder().encode(evidence)
+    print(String(decoding: data, as: UTF8.self))
+    if !evidence.correct {
+        fail("METAL_ARTIFACT_OUTPUT_MISMATCH", code: 26)
+    }
+} catch {
+    fail("METAL_ARTIFACT_FAILED: \(error)", code: 20)
+}
+`;
+
+const TEST_SWIFT = `import XCTest
+@testable import AlphaMetalCore
+
+final class AlphaMetalCoreTests: XCTestCase {
+    func testDeterministicVectorAdd() throws {
+        let evidence = try runMetalVectorAdd()
+        XCTAssertTrue(evidence.correct)
+        XCTAssertEqual(evidence.output, [11, 22, 33, 44])
+        XCTAssertEqual(evidence.expected, [11, 22, 33, 44])
+    }
+}
+`;
+
+async function writeFixedPackage(workDir: string): Promise<string> {
+  const coreDir = join(workDir, "Sources", "AlphaMetalCore");
+  const executableDir = join(workDir, "Sources", "AlphaMetalArtifact");
+  const testDir = join(workDir, "Tests", "AlphaMetalCoreTests");
+  await mkdir(coreDir, { recursive: true });
+  await mkdir(executableDir, { recursive: true });
+  await mkdir(testDir, { recursive: true });
+
+  await writeFile(join(workDir, "Package.swift"), PACKAGE_SWIFT, { mode: 0o600 });
+  await writeFile(join(coreDir, "AlphaMetalCore.swift"), CORE_SWIFT, { mode: 0o600 });
+  await writeFile(join(executableDir, "main.swift"), MAIN_SWIFT, { mode: 0o600 });
+  await writeFile(join(testDir, "AlphaMetalCoreTests.swift"), TEST_SWIFT, { mode: 0o600 });
+
+  return sha256([PACKAGE_SWIFT, CORE_SWIFT, MAIN_SWIFT, TEST_SWIFT].join("\n---\n"));
+}
+
+async function requireSuccessful(
+  label: string,
+  command: string,
+  args: string[],
+  cwd: string,
+): Promise<CommandResult> {
+  const result = await runFixedCommand(command, args, cwd);
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `${label}_FAILED exit=${result.exitCode} stderr=${result.stderr || "<empty>"}`,
+    );
+  }
+  return result;
+}
+
+export function registerAppleRunnerBuild(server: CustomMcpServer) {
+  server.tool({
+    name: AppleRunnerBuildOperationId,
+    description:
+      "Build and test the fixed APPLE-RUNNER-001 Swift/Metal package, persist its executable and logs, and return a signed artifact manifest. Requires a Warden-signed single-use build capability.",
+    annotations: { destructiveHint: false, idempotentHint: false },
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        runnerRef: { type: "string", minLength: 1 },
+        fixture: { type: "string", enum: [FIXTURE_ID] },
+        capabilityToken: { type: "string", minLength: 16 },
+      },
+      required: ["runnerRef", "fixture", "capabilityToken"],
+    },
+    cb: async (args) => {
+      const input = args as {
+        runnerRef: string;
+        fixture: typeof FIXTURE_ID;
+        capabilityToken: string;
+      };
+
+      const capability = verifyWardenCapability(input.capabilityToken, input.runnerRef);
+      const artifactSigningSecret = process.env.ALPHA_ARTIFACT_HMAC_SECRET;
+      if (!artifactSigningSecret) {
+        throw new Error("ARTIFACT_SIGNER_NOT_CONFIGURED");
+      }
+      if (process.platform !== "darwin") {
+        throw new Error("APPLE_RUNNER_REQUIRES_MACOS");
+      }
+
+      await consumeReplayNonce(capability);
+
+      const workDir = await mkdtemp(join(tmpdir(), "alpha-apple-build-"));
+      try {
+        const sourceSha256 = await writeFixedPackage(workDir);
+        const build = await requireSuccessful(
+          "APPLE_SWIFT_BUILD",
+          "xcrun",
+          ["swift", "build", "-c", "release", "--product", PRODUCT_NAME],
+          workDir,
+        );
+        const tests = await requireSuccessful(
+          "APPLE_SWIFT_TEST",
+          "xcrun",
+          ["swift", "test", "-c", "release"],
+          workDir,
+        );
+        const binPathResult = await requireSuccessful(
+          "APPLE_SWIFT_BIN_PATH",
+          "xcrun",
+          ["swift", "build", "-c", "release", "--show-bin-path"],
+          workDir,
+        );
+
+        const binRoot = resolve(binPathResult.stdout);
+        const resolvedWorkDir = resolve(workDir);
+        if (!binRoot.startsWith(`${resolvedWorkDir}${sep}`)) {
+          throw new Error("APPLE_BUILD_BIN_PATH_OUTSIDE_WORKDIR");
+        }
+        const executablePath = join(binRoot, PRODUCT_NAME);
+        const verification = await requireSuccessful(
+          "APPLE_ARTIFACT_SELF_TEST",
+          executablePath,
+          [],
+          workDir,
+        );
+        const evidence = JSON.parse(verification.stdout) as {
+          correct?: boolean;
+          output?: number[];
+          expected?: number[];
+          [key: string]: unknown;
+        };
+        if (
+          evidence.correct !== true ||
+          JSON.stringify(evidence.output) !== JSON.stringify([11, 22, 33, 44])
+        ) {
+          throw new Error("APPLE_ARTIFACT_VERIFICATION_MISMATCH");
+        }
+
+        const executable = await readFile(executablePath);
+        const executableStats = await stat(executablePath);
+        const artifactSha256 = sha256(executable);
+        const buildLog = `${build.stdout}\n${build.stderr}`.trim();
+        const testLog = `${tests.stdout}\n${tests.stderr}`.trim();
+        const runId = sha256(`${capability.capabilityId}\0${capability.nonce}`).slice(0, 24);
+        const artifactRoot =
+          process.env.ALPHA_APPLE_ARTIFACT_DIR ?? join(tmpdir(), "alpha-apple-artifacts");
+        await mkdir(artifactRoot, { recursive: true });
+        const runDir = join(artifactRoot, runId);
+        try {
+          await mkdir(runDir, { recursive: false, mode: 0o700 });
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+            throw new Error("APPLE_ARTIFACT_ALREADY_EXISTS");
+          }
+          throw error;
+        }
+
+        const persistedExecutable = join(runDir, PRODUCT_NAME);
+        await copyFile(executablePath, persistedExecutable);
+        await chmod(persistedExecutable, 0o700);
+        await writeFile(join(runDir, "build.log"), buildLog, { mode: 0o600 });
+        await writeFile(join(runDir, "test.log"), testLog, { mode: 0o600 });
+
+        const os = await requireSuccessful("APPLE_SW_VERS", "sw_vers", ["-productVersion"], workDir);
+        const xcode = await requireSuccessful("APPLE_XCODE_VERSION", "xcodebuild", ["-version"], workDir);
+        const swift = await requireSuccessful("APPLE_SWIFT_VERSION", "xcrun", ["swift", "--version"], workDir);
+
+        const artifactRef = `apple-runner://${input.runnerRef}/${runId}/${PRODUCT_NAME}`;
+        const manifest = {
+          schema: "APPLE-RUNNER-ARTIFACT-MANIFEST-001",
+          artifactId: `APPLE-ARTIFACT-${runId}`,
+          artifactRef,
+          fixture: input.fixture,
+          runnerRef: input.runnerRef,
+          capability: {
+            capabilityId: capability.capabilityId,
+            principal: capability.principal,
+            workspaceRef: capability.workspaceRef,
+            nonce: capability.nonce,
+          },
+          artifact: {
+            name: PRODUCT_NAME,
+            configuration: "release",
+            sha256: artifactSha256,
+            sizeBytes: executableStats.size,
+          },
+          sourceSha256,
+          verification: {
+            testsPassed: true,
+            artifactSelfTestPassed: true,
+            evidence,
+            buildLogSha256: sha256(buildLog),
+            testLogSha256: sha256(testLog),
+          },
+          toolchain: {
+            macOS: os.stdout,
+            xcode: xcode.stdout,
+            swift: swift.stdout,
+          },
+          provenance: {
+            repository: process.env.GITHUB_REPOSITORY ?? null,
+            gitCommit: process.env.GITHUB_SHA ?? null,
+          },
+          generatedAt: new Date().toISOString(),
+        };
+        const manifestJson = JSON.stringify(manifest);
+        const signature = createHmac("sha256", artifactSigningSecret)
+          .update(manifestJson)
+          .digest("base64url");
+        await writeFile(join(runDir, "manifest.json"), manifestJson, { mode: 0o600 });
+        await writeFile(join(runDir, "manifest.sig"), signature, { mode: 0o600 });
+
+        return JSON.stringify({
+          schema: "APPLE-RUNNER-BUILD-EXECUTION-001",
+          runnerRef: input.runnerRef,
+          fixture: input.fixture,
+          executionPolicy: {
+            shell: false,
+            arbitraryCommandExecution: false,
+            allowedCommands: [
+              "xcrun swift build -c release --product alpha-metal-artifact",
+              "xcrun swift test -c release",
+              "xcrun swift build -c release --show-bin-path",
+              "<built-fixed-artifact>",
+              "sw_vers -productVersion",
+              "xcodebuild -version",
+              "xcrun swift --version",
+            ],
+          },
+          manifest,
+          manifestSignature: {
+            algorithm: "HMAC-SHA256",
+            value: signature,
+          },
+          storage: {
+            artifactRef,
+            durableStorageConfigured: Boolean(process.env.ALPHA_APPLE_ARTIFACT_DIR),
+          },
+        });
+      } finally {
+        await rm(workDir, { recursive: true, force: true });
+      }
+    },
+  });
+}

--- a/src/tools/registerAppleRunnerCanary.test.ts
+++ b/src/tools/registerAppleRunnerCanary.test.ts
@@ -1,0 +1,107 @@
+import { createHmac } from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+import type { CustomMcpServer } from "../CustomMcpServer.ts";
+import {
+  AppleRunnerOperationId,
+  registerAppleRunnerCanary,
+  type WardenCapabilityPayload,
+} from "./registerAppleRunnerCanary.ts";
+
+type CapturedTool = {
+  name: string;
+  cb: (...args: unknown[]) => string | Promise<string>;
+};
+
+function captureTool(): CapturedTool {
+  const tools: CapturedTool[] = [];
+  const server = {
+    tool(definition: CapturedTool) {
+      tools.push(definition);
+    },
+  } as unknown as CustomMcpServer;
+
+  registerAppleRunnerCanary(server);
+  expect(tools).toHaveLength(1);
+  return tools[0]!;
+}
+
+function makeToken(secret: string, overrides: Partial<WardenCapabilityPayload> = {}): string {
+  const now = Date.now();
+  const payload: WardenCapabilityPayload = {
+    schema: "ALPHA-WARDEN-CAPABILITY-001",
+    issuedBy: "WARDEN",
+    status: "AUTHORIZED",
+    capabilityId: "CAP-TEST-001",
+    principal: "DM-TEST-001",
+    workspaceRef: "ALPHA-NODE-001",
+    tool: AppleRunnerOperationId,
+    runnerRef: "APPLE-RUNNER-001",
+    scopes: ["APPLE-RUNNER-001:METAL-CANARY"],
+    nonce: "NONCE-TEST-001",
+    issuedAt: new Date(now - 1_000).toISOString(),
+    expiresAt: new Date(now + 60_000).toISOString(),
+    ...overrides,
+  };
+  const payloadPart = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  const signature = createHmac("sha256", secret).update(payloadPart).digest("base64url");
+  return `${payloadPart}.${signature}`;
+}
+
+const originalSecret = process.env.ALPHA_WARDEN_HMAC_SECRET;
+
+afterEach(() => {
+  if (originalSecret === undefined) {
+    delete process.env.ALPHA_WARDEN_HMAC_SECRET;
+  } else {
+    process.env.ALPHA_WARDEN_HMAC_SECRET = originalSecret;
+  }
+});
+
+describe("APPLE-RUNNER-001 canary", () => {
+  it("registers exactly one fixed execution tool", () => {
+    expect(captureTool().name).toBe(AppleRunnerOperationId);
+  });
+
+  it("refuses execution when the Warden verifier secret is not configured", async () => {
+    delete process.env.ALPHA_WARDEN_HMAC_SECRET;
+    const tool = captureTool();
+
+    await expect(
+      tool.cb({
+        runnerRef: "APPLE-RUNNER-001",
+        fixture: "vector-add-f32-v1",
+        capabilityToken: "not-a-real-token",
+      }),
+    ).rejects.toThrow("WARDEN_AUTHORITY_VERIFIER_NOT_CONFIGURED");
+  });
+
+  it("rejects a capability signed for a different runner", async () => {
+    const secret = "test-only-secret";
+    process.env.ALPHA_WARDEN_HMAC_SECRET = secret;
+    const tool = captureTool();
+
+    await expect(
+      tool.cb({
+        runnerRef: "APPLE-RUNNER-001",
+        fixture: "vector-add-f32-v1",
+        capabilityToken: makeToken(secret, { runnerRef: "APPLE-RUNNER-999" }),
+      }),
+    ).rejects.toThrow("WARDEN_CAPABILITY_RUNNER_MISMATCH");
+  });
+
+  it("accepts valid authority before applying the macOS execution boundary", async () => {
+    const secret = "test-only-secret";
+    process.env.ALPHA_WARDEN_HMAC_SECRET = secret;
+    const tool = captureTool();
+
+    if (process.platform !== "darwin") {
+      await expect(
+        tool.cb({
+          runnerRef: "APPLE-RUNNER-001",
+          fixture: "vector-add-f32-v1",
+          capabilityToken: makeToken(secret),
+        }),
+      ).rejects.toThrow("APPLE_RUNNER_REQUIRES_MACOS");
+    }
+  });
+});

--- a/src/tools/registerAppleRunnerCanary.test.ts
+++ b/src/tools/registerAppleRunnerCanary.test.ts
@@ -37,7 +37,7 @@ function makeToken(secret: string, overrides: Partial<WardenCapabilityPayload> =
     tool: AppleRunnerOperationId,
     runnerRef: "APPLE-RUNNER-001",
     scopes: ["APPLE-RUNNER-001:METAL-CANARY"],
-    nonce: "NONCE-TEST-001",
+    nonce: `NONCE-TEST-${process.pid}`,
     issuedAt: new Date(now - 1_000).toISOString(),
     expiresAt: new Date(now + 60_000).toISOString(),
     ...overrides,
@@ -89,19 +89,28 @@ describe("APPLE-RUNNER-001 canary", () => {
     ).rejects.toThrow("WARDEN_CAPABILITY_RUNNER_MISMATCH");
   });
 
-  it("accepts valid authority before applying the macOS execution boundary", async () => {
+  it("physically executes the deterministic Metal fixture on macOS", async () => {
     const secret = "test-only-secret";
     process.env.ALPHA_WARDEN_HMAC_SECRET = secret;
     const tool = captureTool();
+    const input = {
+      runnerRef: "APPLE-RUNNER-001",
+      fixture: "vector-add-f32-v1",
+      capabilityToken: makeToken(secret),
+    };
 
     if (process.platform !== "darwin") {
-      await expect(
-        tool.cb({
-          runnerRef: "APPLE-RUNNER-001",
-          fixture: "vector-add-f32-v1",
-          capabilityToken: makeToken(secret),
-        }),
-      ).rejects.toThrow("APPLE_RUNNER_REQUIRES_MACOS");
+      await expect(tool.cb(input)).rejects.toThrow("APPLE_RUNNER_REQUIRES_MACOS");
+      return;
     }
+
+    const result = JSON.parse(await tool.cb(input));
+    expect(result.schema).toBe("APPLE-RUNNER-EXECUTION-001");
+    expect(result.runnerRef).toBe("APPLE-RUNNER-001");
+    expect(result.commandPolicy.arbitraryCommandExecution).toBe(false);
+    expect(result.evidence.schema).toBe("APPLE-RUNNER-METAL-EVIDENCE-001");
+    expect(result.evidence.fixture).toBe("vector-add-f32-v1");
+    expect(result.evidence.output).toEqual([11, 22, 33, 44]);
+    expect(result.evidence.correct).toBe(true);
   });
 });

--- a/src/tools/registerAppleRunnerCanary.test.ts
+++ b/src/tools/registerAppleRunnerCanary.test.ts
@@ -89,28 +89,32 @@ describe("APPLE-RUNNER-001 canary", () => {
     ).rejects.toThrow("WARDEN_CAPABILITY_RUNNER_MISMATCH");
   });
 
-  it("physically executes the deterministic Metal fixture on macOS", async () => {
-    const secret = "test-only-secret";
-    process.env.ALPHA_WARDEN_HMAC_SECRET = secret;
-    const tool = captureTool();
-    const input = {
-      runnerRef: "APPLE-RUNNER-001",
-      fixture: "vector-add-f32-v1",
-      capabilityToken: makeToken(secret),
-    };
+  it(
+    "physically executes the deterministic Metal fixture on macOS",
+    async () => {
+      const secret = "test-only-secret";
+      process.env.ALPHA_WARDEN_HMAC_SECRET = secret;
+      const tool = captureTool();
+      const input = {
+        runnerRef: "APPLE-RUNNER-001",
+        fixture: "vector-add-f32-v1",
+        capabilityToken: makeToken(secret),
+      };
 
-    if (process.platform !== "darwin") {
-      await expect(tool.cb(input)).rejects.toThrow("APPLE_RUNNER_REQUIRES_MACOS");
-      return;
-    }
+      if (process.platform !== "darwin") {
+        await expect(tool.cb(input)).rejects.toThrow("APPLE_RUNNER_REQUIRES_MACOS");
+        return;
+      }
 
-    const result = JSON.parse(await tool.cb(input));
-    expect(result.schema).toBe("APPLE-RUNNER-EXECUTION-001");
-    expect(result.runnerRef).toBe("APPLE-RUNNER-001");
-    expect(result.commandPolicy.arbitraryCommandExecution).toBe(false);
-    expect(result.evidence.schema).toBe("APPLE-RUNNER-METAL-EVIDENCE-001");
-    expect(result.evidence.fixture).toBe("vector-add-f32-v1");
-    expect(result.evidence.output).toEqual([11, 22, 33, 44]);
-    expect(result.evidence.correct).toBe(true);
-  });
+      const result = JSON.parse(await tool.cb(input));
+      expect(result.schema).toBe("APPLE-RUNNER-EXECUTION-001");
+      expect(result.runnerRef).toBe("APPLE-RUNNER-001");
+      expect(result.commandPolicy.arbitraryCommandExecution).toBe(false);
+      expect(result.evidence.schema).toBe("APPLE-RUNNER-METAL-EVIDENCE-001");
+      expect(result.evidence.fixture).toBe("vector-add-f32-v1");
+      expect(result.evidence.output).toEqual([11, 22, 33, 44]);
+      expect(result.evidence.correct).toBe(true);
+    },
+    60_000,
+  );
 });

--- a/src/tools/registerAppleRunnerCanary.ts
+++ b/src/tools/registerAppleRunnerCanary.ts
@@ -1,0 +1,350 @@
+import { spawn } from "node:child_process";
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { CustomMcpServer } from "../CustomMcpServer.ts";
+
+export const AppleRunnerOperationId = "appleRunnerRunMetalCanary";
+const REQUIRED_SCOPE = "APPLE-RUNNER-001:METAL-CANARY";
+const FIXTURE_ID = "vector-add-f32-v1";
+const MAX_OUTPUT_BYTES = 64 * 1024;
+const EXECUTION_TIMEOUT_MS = 60_000;
+
+export type WardenCapabilityPayload = {
+  schema: "ALPHA-WARDEN-CAPABILITY-001";
+  issuedBy: "WARDEN";
+  status: "AUTHORIZED";
+  capabilityId: string;
+  principal: string;
+  workspaceRef: string;
+  tool: typeof AppleRunnerOperationId;
+  runnerRef: string;
+  scopes: string[];
+  nonce: string;
+  issuedAt: string;
+  expiresAt: string;
+};
+
+function decodeBase64Url(value: string): Buffer {
+  return Buffer.from(value, "base64url");
+}
+
+function verifyWardenCapability(token: string, runnerRef: string): WardenCapabilityPayload {
+  const secret = process.env.ALPHA_WARDEN_HMAC_SECRET;
+  if (!secret) {
+    throw new Error("WARDEN_AUTHORITY_VERIFIER_NOT_CONFIGURED");
+  }
+
+  const [payloadPart, signaturePart, ...extra] = token.split(".");
+  if (!payloadPart || !signaturePart || extra.length) {
+    throw new Error("INVALID_WARDEN_CAPABILITY_TOKEN");
+  }
+
+  const expectedSignature = createHmac("sha256", secret).update(payloadPart).digest();
+  const actualSignature = decodeBase64Url(signaturePart);
+  if (
+    actualSignature.length !== expectedSignature.length ||
+    !timingSafeEqual(actualSignature, expectedSignature)
+  ) {
+    throw new Error("INVALID_WARDEN_CAPABILITY_SIGNATURE");
+  }
+
+  let payload: WardenCapabilityPayload;
+  try {
+    payload = JSON.parse(decodeBase64Url(payloadPart).toString("utf8")) as WardenCapabilityPayload;
+  } catch {
+    throw new Error("INVALID_WARDEN_CAPABILITY_PAYLOAD");
+  }
+
+  if (
+    payload.schema !== "ALPHA-WARDEN-CAPABILITY-001" ||
+    payload.issuedBy !== "WARDEN" ||
+    payload.status !== "AUTHORIZED"
+  ) {
+    throw new Error("WARDEN_CAPABILITY_NOT_AUTHORIZED");
+  }
+  if (payload.tool !== AppleRunnerOperationId) {
+    throw new Error("WARDEN_CAPABILITY_TOOL_MISMATCH");
+  }
+  if (payload.runnerRef !== runnerRef) {
+    throw new Error("WARDEN_CAPABILITY_RUNNER_MISMATCH");
+  }
+  if (!payload.scopes?.includes(REQUIRED_SCOPE)) {
+    throw new Error("WARDEN_CAPABILITY_SCOPE_MISSING");
+  }
+  if (!payload.capabilityId || !payload.principal || !payload.workspaceRef || !payload.nonce) {
+    throw new Error("WARDEN_CAPABILITY_CONTEXT_INCOMPLETE");
+  }
+
+  const issuedAt = Date.parse(payload.issuedAt);
+  const expiresAt = Date.parse(payload.expiresAt);
+  const now = Date.now();
+  if (!Number.isFinite(issuedAt) || !Number.isFinite(expiresAt) || issuedAt > now + 60_000) {
+    throw new Error("WARDEN_CAPABILITY_TIME_INVALID");
+  }
+  if (expiresAt <= now) {
+    throw new Error("WARDEN_CAPABILITY_EXPIRED");
+  }
+
+  return payload;
+}
+
+async function consumeReplayNonce(payload: WardenCapabilityPayload): Promise<void> {
+  const replayRoot = process.env.ALPHA_WARDEN_REPLAY_DIR ?? join(tmpdir(), "alpha-newton-replay");
+  await mkdir(replayRoot, { recursive: true });
+  const marker = join(replayRoot, `${payload.capabilityId}-${payload.nonce}.used`);
+
+  try {
+    await writeFile(
+      marker,
+      JSON.stringify({ capabilityId: payload.capabilityId, nonce: payload.nonce, usedAt: new Date().toISOString() }),
+      { flag: "wx", mode: 0o600 },
+    );
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "EEXIST") {
+      throw new Error("WARDEN_CAPABILITY_REPLAY_DETECTED");
+    }
+    throw error;
+  }
+}
+
+const SWIFT_METAL_CANARY = String.raw`import Foundation
+import Metal
+
+struct Evidence: Codable {
+    let schema: String
+    let fixture: String
+    let deviceName: String
+    let registryID: UInt64
+    let lowPower: Bool
+    let removable: Bool
+    let unifiedMemory: Bool
+    let osVersion: String
+    let output: [Float]
+    let expected: [Float]
+    let correct: Bool
+    let cpuElapsedMs: Double
+    let gpuElapsedMs: Double?
+}
+
+guard let device = MTLCreateSystemDefaultDevice() else {
+    fputs("METAL_DEVICE_UNAVAILABLE\n", stderr)
+    exit(20)
+}
+
+guard let queue = device.makeCommandQueue() else {
+    fputs("METAL_COMMAND_QUEUE_UNAVAILABLE\n", stderr)
+    exit(21)
+}
+
+let source = """
+#include <metal_stdlib>
+using namespace metal;
+kernel void vector_add(const device float* a [[buffer(0)]],
+                       const device float* b [[buffer(1)]],
+                       device float* out [[buffer(2)]],
+                       uint id [[thread_position_in_grid]]) {
+    out[id] = a[id] + b[id];
+}
+"""
+
+let library: MTLLibrary
+let function: MTLFunction
+let pipeline: MTLComputePipelineState
+
+do {
+    library = try device.makeLibrary(source: source, options: nil)
+    guard let resolved = library.makeFunction(name: "vector_add") else {
+        fputs("METAL_FUNCTION_UNAVAILABLE\n", stderr)
+        exit(22)
+    }
+    function = resolved
+    pipeline = try device.makeComputePipelineState(function: function)
+} catch {
+    fputs("METAL_PIPELINE_BUILD_FAILED: \(error)\n", stderr)
+    exit(23)
+}
+
+let a: [Float] = [1, 2, 3, 4]
+let b: [Float] = [10, 20, 30, 40]
+let expected: [Float] = [11, 22, 33, 44]
+let byteCount = a.count * MemoryLayout<Float>.stride
+
+guard let aBuffer = device.makeBuffer(bytes: a, length: byteCount),
+      let bBuffer = device.makeBuffer(bytes: b, length: byteCount),
+      let outBuffer = device.makeBuffer(length: byteCount),
+      let commandBuffer = queue.makeCommandBuffer(),
+      let encoder = commandBuffer.makeComputeCommandEncoder() else {
+    fputs("METAL_RESOURCE_ALLOCATION_FAILED\n", stderr)
+    exit(24)
+}
+
+encoder.setComputePipelineState(pipeline)
+encoder.setBuffer(aBuffer, offset: 0, index: 0)
+encoder.setBuffer(bBuffer, offset: 0, index: 1)
+encoder.setBuffer(outBuffer, offset: 0, index: 2)
+let width = min(pipeline.maxTotalThreadsPerThreadgroup, a.count)
+encoder.dispatchThreads(
+    MTLSize(width: a.count, height: 1, depth: 1),
+    threadsPerThreadgroup: MTLSize(width: width, height: 1, depth: 1)
+)
+encoder.endEncoding()
+
+let start = DispatchTime.now().uptimeNanoseconds
+commandBuffer.commit()
+commandBuffer.waitUntilCompleted()
+let end = DispatchTime.now().uptimeNanoseconds
+
+if commandBuffer.status != .completed {
+    fputs("METAL_COMMAND_FAILED: \(String(describing: commandBuffer.error))\n", stderr)
+    exit(25)
+}
+
+let values = outBuffer.contents().bindMemory(to: Float.self, capacity: a.count)
+let output = Array(UnsafeBufferPointer(start: values, count: a.count))
+let correct = output == expected
+let gpuElapsed = commandBuffer.gpuEndTime > commandBuffer.gpuStartTime
+    ? (commandBuffer.gpuEndTime - commandBuffer.gpuStartTime) * 1000.0
+    : nil
+let evidence = Evidence(
+    schema: "APPLE-RUNNER-METAL-EVIDENCE-001",
+    fixture: "vector-add-f32-v1",
+    deviceName: device.name,
+    registryID: device.registryID,
+    lowPower: device.isLowPower,
+    removable: device.isRemovable,
+    unifiedMemory: device.hasUnifiedMemory,
+    osVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+    output: output,
+    expected: expected,
+    correct: correct,
+    cpuElapsedMs: Double(end - start) / 1_000_000.0,
+    gpuElapsedMs: gpuElapsed
+)
+
+let data = try JSONEncoder().encode(evidence)
+print(String(decoding: data, as: UTF8.self))
+if !correct { exit(26) }
+`;
+
+function runFixedCommand(command: string, args: string[], cwd: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: { ...process.env },
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = Buffer.alloc(0);
+    let stderr = Buffer.alloc(0);
+    let killedForOutput = false;
+
+    const append = (current: Buffer, chunk: Buffer): Buffer => {
+      const next = Buffer.concat([current, chunk]);
+      if (next.length > MAX_OUTPUT_BYTES) {
+        killedForOutput = true;
+        child.kill("SIGKILL");
+        return next.subarray(0, MAX_OUTPUT_BYTES);
+      }
+      return next;
+    };
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout = append(stdout, chunk);
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr = append(stderr, chunk);
+    });
+
+    const timeout = setTimeout(() => child.kill("SIGKILL"), EXECUTION_TIMEOUT_MS);
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      if (killedForOutput) {
+        reject(new Error("APPLE_RUNNER_OUTPUT_LIMIT_EXCEEDED"));
+        return;
+      }
+      resolve({
+        stdout: stdout.toString("utf8").trim(),
+        stderr: stderr.toString("utf8").trim(),
+        exitCode: code ?? -1,
+      });
+    });
+  });
+}
+
+export function registerAppleRunnerCanary(server: CustomMcpServer) {
+  server.tool({
+    name: AppleRunnerOperationId,
+    description:
+      "Execute the fixed APPLE-RUNNER-001 Metal vector-add canary on an authorized macOS runner and return structured evidence. Requires a Warden-signed, single-use capability token.",
+    annotations: { destructiveHint: false, idempotentHint: false },
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        runnerRef: { type: "string", minLength: 1 },
+        fixture: { type: "string", enum: [FIXTURE_ID] },
+        capabilityToken: { type: "string", minLength: 16 },
+      },
+      required: ["runnerRef", "fixture", "capabilityToken"],
+    },
+    cb: async (args) => {
+      const input = args as {
+        runnerRef: string;
+        fixture: typeof FIXTURE_ID;
+        capabilityToken: string;
+      };
+
+      const capability = verifyWardenCapability(input.capabilityToken, input.runnerRef);
+      if (process.platform !== "darwin") {
+        throw new Error("APPLE_RUNNER_REQUIRES_MACOS");
+      }
+
+      // Consume only immediately before execution so routing mistakes do not burn the capability.
+      await consumeReplayNonce(capability);
+
+      const workDir = await mkdtemp(join(tmpdir(), "alpha-apple-runner-"));
+      const scriptPath = join(workDir, "metal_canary.swift");
+      try {
+        await writeFile(scriptPath, SWIFT_METAL_CANARY, { mode: 0o600 });
+        const result = await runFixedCommand("xcrun", ["swift", scriptPath], workDir);
+        if (result.exitCode !== 0) {
+          throw new Error(
+            `APPLE_RUNNER_CANARY_FAILED exit=${result.exitCode} stderr=${result.stderr || "<empty>"}`,
+          );
+        }
+
+        const evidence = JSON.parse(result.stdout) as Record<string, unknown>;
+        return JSON.stringify({
+          schema: "APPLE-RUNNER-EXECUTION-001",
+          runnerRef: input.runnerRef,
+          fixture: input.fixture,
+          capability: {
+            capabilityId: capability.capabilityId,
+            principal: capability.principal,
+            workspaceRef: capability.workspaceRef,
+            nonce: capability.nonce,
+          },
+          commandPolicy: {
+            shell: false,
+            executable: "xcrun",
+            arguments: ["swift", "<generated-fixed-fixture>"],
+            arbitraryCommandExecution: false,
+          },
+          evidence,
+          stderr: result.stderr || null,
+          executedAt: new Date().toISOString(),
+        });
+      } finally {
+        await rm(workDir, { recursive: true, force: true });
+      }
+    },
+  });
+}


### PR DESCRIPTION
## What this adds
- standalone `start-alpha-newton-server` MCP command with no Algolia authentication dependency
- five planning-only Alpha/Newton tools for Metal/MPS capability discovery, workload planning, Apple-runner routing, governed DevOps planning, and Warden authority-envelope creation
- `APPLE-RUNNER-001` deterministic Metal canary via `appleRunnerRunMetalCanary`
- governed Swift/Metal build adapter via `appleRunnerBuildSwiftArtifact`
- fixed `metal-vector-add-package-v1` package build; no arbitrary command/script/path/source input
- release `swift build`, physical `swift test`, built-artifact self-test, executable SHA-256 and source SHA-256
- separate HMAC-SHA256 Warden capability verification and artifact-manifest signing secrets
- single-use replay nonce markers before execution
- macOS-only execution with `shell: false`, bounded output and hard timeouts
- runner-controlled artifact persistence for executable, build/test logs, `manifest.json`, and `manifest.sig`
- structured evidence for Metal device, OS, Xcode/Swift identities, correctness, hashes, authority context and Git provenance
- dedicated macOS GitHub Actions verification for both the Metal canary and governed build adapter

## Architecture boundary
Newton is a builder/operator tool surface. Alpha Registry/Warden remain authoritative. Planning remains non-executing. APPLE-RUNNER-001 executes only fixed fixtures after a Warden-signed capability is verified. Linux/Gram control-plane hosts may orchestrate runs and ingest evidence but do not claim local Metal execution.

## Verification
- `npm run type-check`
- `npm run lint`
- `npm test -- --run`
- macOS physical Metal canary
- macOS physical Swift package build/test/artifact self-test
- Datadog synthetics skip cleanly when optional repo credentials are absent

## Still intentionally out of scope
- arbitrary shell execution
- user-supplied source/repository build execution
- production deployment adapter
- Apple code signing/notarization/App Store distribution
- raw Registry/database credentials in Newton
- Newton-specific private API integration (no workspace API contract was assumed)
- production-grade distributed replay storage; `ALPHA_WARDEN_REPLAY_DIR` should be durable before assurance use
- production artifact storage; configure `ALPHA_APPLE_ARTIFACT_DIR` to a durable runner-local path
