### PR TITLE
feat(alpha): federate BC, CC and VSR public sites

### DIFF
--- a/api/sites.test.ts
+++ b/api/sites.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ESTATE_SITE_REGISTRY,
+  isAllowedSiteOrigin,
+  resolveSite,
+} from "./sites.ts";
+
+describe("REG-SITE-001 estate site federation", () => {
+  it("contains exactly BC, CC and VSR under one Alpha node", () => {
+    expect(ESTATE_SITE_REGISTRY.sites.map((site) => site.id)).toEqual(["bc", "cc", "vsr"]);
+    expect(new Set(ESTATE_SITE_REGISTRY.sites.map((site) => site.alpha_node_id))).toEqual(
+      new Set(["ALPHA-NODE-001"]),
+    );
+  });
+
+  it("keeps Warden as authority rather than any website", () => {
+    expect(ESTATE_SITE_REGISTRY.authority_boundary).toBe("WARDEN");
+    for (const site of ESTATE_SITE_REGISTRY.sites) {
+      expect(site.authority_boundary).toBe("WARDEN");
+    }
+  });
+
+  it("does not use a shared cross-domain cookie as identity continuity", () => {
+    expect(ESTATE_SITE_REGISTRY.session_policy).toBe("NO_SHARED_CROSS_DOMAIN_COOKIE");
+  });
+
+  it("resolves each site deterministically", () => {
+    expect(resolveSite("bc")?.canonical_url).toBe("https://believerscommon.com");
+    expect(resolveSite("cc")?.canonical_url).toBe("https://creators-common.org");
+    expect(resolveSite("vsr")?.canonical_url).toBe("https://virtualsilkroad.com");
+    expect(resolveSite("unknown")).toBeUndefined();
+  });
+
+  it("allows canonical site origins and Vercel release previews only", () => {
+    expect(isAllowedSiteOrigin("https://believerscommon.com")).toBe(true);
+    expect(isAllowedSiteOrigin("https://www.creators-common.org")).toBe(true);
+    expect(isAllowedSiteOrigin("https://preview-123.vercel.app")).toBe(true);
+    expect(isAllowedSiteOrigin("https://attacker.example")).toBe(false);
+  });
+});

--- a/api/sites.ts
+++ b/api/sites.ts
@@ -1,0 +1,131 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+export type EstateSiteId = "bc" | "cc" | "vsr";
+
+export interface EstateSite {
+  id: EstateSiteId;
+  name: string;
+  canonical_url: string;
+  role: string;
+  alpha_node_id: "ALPHA-NODE-001";
+  registry_object: "REG-SITE-001";
+  authority_boundary: "WARDEN";
+  navigation: EstateSiteId[];
+}
+
+export interface EstateSiteRegistry {
+  schema_version: "1.0";
+  registry_object: "REG-SITE-001";
+  alpha_node_id: "ALPHA-NODE-001";
+  authority_boundary: "WARDEN";
+  session_policy: "NO_SHARED_CROSS_DOMAIN_COOKIE";
+  sites: EstateSite[];
+}
+
+export const ESTATE_SITE_REGISTRY: EstateSiteRegistry = {
+  schema_version: "1.0",
+  registry_object: "REG-SITE-001",
+  alpha_node_id: "ALPHA-NODE-001",
+  authority_boundary: "WARDEN",
+  session_policy: "NO_SHARED_CROSS_DOMAIN_COOKIE",
+  sites: [
+    {
+      id: "bc",
+      name: "Believers Common",
+      canonical_url: "https://believerscommon.com",
+      role: "governance-and-participation-entry",
+      alpha_node_id: "ALPHA-NODE-001",
+      registry_object: "REG-SITE-001",
+      authority_boundary: "WARDEN",
+      navigation: ["cc", "vsr"],
+    },
+    {
+      id: "cc",
+      name: "Creators Common",
+      canonical_url: "https://creators-common.org",
+      role: "creator-and-shared-commons",
+      alpha_node_id: "ALPHA-NODE-001",
+      registry_object: "REG-SITE-001",
+      authority_boundary: "WARDEN",
+      navigation: ["bc", "vsr"],
+    },
+    {
+      id: "vsr",
+      name: "Virtual Silk Road",
+      canonical_url: "https://virtualsilkroad.com",
+      role: "front-gate-and-participation-network",
+      alpha_node_id: "ALPHA-NODE-001",
+      registry_object: "REG-SITE-001",
+      authority_boundary: "WARDEN",
+      navigation: ["bc", "cc"],
+    },
+  ],
+};
+
+export function resolveSite(id: string | undefined): EstateSite | undefined {
+  return ESTATE_SITE_REGISTRY.sites.find((site) => site.id === id);
+}
+
+export function isAllowedSiteOrigin(origin: string | undefined): boolean {
+  if (!origin) return false;
+  if (
+    origin === "https://believerscommon.com" ||
+    origin === "https://www.believerscommon.com" ||
+    origin === "https://creators-common.org" ||
+    origin === "https://www.creators-common.org" ||
+    origin === "https://virtualsilkroad.com" ||
+    origin === "https://www.virtualsilkroad.com"
+  ) {
+    return true;
+  }
+
+  return /^https:\/\/[a-z0-9-]+\.vercel\.app$/i.test(origin);
+}
+
+function requestUrl(request: IncomingMessage): URL {
+  return new URL(request.url || "/api/sites", "https://alpha.invalid");
+}
+
+export default function handler(request: IncomingMessage, response: ServerResponse) {
+  const origin = request.headers.origin;
+  if (isAllowedSiteOrigin(origin)) {
+    response.setHeader("access-control-allow-origin", origin as string);
+    response.setHeader("vary", "Origin");
+  }
+  response.setHeader("access-control-allow-methods", "GET, OPTIONS");
+  response.setHeader("access-control-allow-headers", "content-type");
+  response.setHeader("cache-control", "public, max-age=60, s-maxage=300");
+
+  if (request.method === "OPTIONS") {
+    response.statusCode = 204;
+    response.end();
+    return;
+  }
+
+  if (request.method !== "GET") {
+    response.statusCode = 405;
+    response.setHeader("content-type", "application/json; charset=utf-8");
+    response.end(JSON.stringify({ ok: false, error: "method_not_allowed" }));
+    return;
+  }
+
+  const url = requestUrl(request);
+  const requestedId = url.searchParams.get("id") || undefined;
+  if (requestedId) {
+    const site = resolveSite(requestedId);
+    if (!site) {
+      response.statusCode = 404;
+      response.setHeader("content-type", "application/json; charset=utf-8");
+      response.end(JSON.stringify({ ok: false, error: "site_not_found" }));
+      return;
+    }
+    response.statusCode = 200;
+    response.setHeader("content-type", "application/json; charset=utf-8");
+    response.end(JSON.stringify({ ok: true, site }));
+    return;
+  }
+
+  response.statusCode = 200;
+  response.setHeader("content-type", "application/json; charset=utf-8");
+  response.end(JSON.stringify({ ok: true, registry: ESTATE_SITE_REGISTRY }));
+}

--- a/docs/alpha-node/REG-SITE-001.md
+++ b/docs/alpha-node/REG-SITE-001.md
@@ -1,0 +1,78 @@
+# REG-SITE-001 — Estate Site Federation
+
+Status: `ALPHA-RELEASE-003 / FIRST-SLICE`
+Scope: Believers Common (BC), Creators Common (CC), Virtual Silk Road (VSR)
+Containing node: `ALPHA-NODE-001`
+Authority boundary: `WARDEN`
+
+## Purpose
+
+Connect the three public web surfaces without creating three competing identity, authority or Registry systems.
+
+```text
+Believers Common  <---- site navigation ---->  Creators Common
+       \                                      /
+        \                                    /
+         +-------- Virtual Silk Road --------+
+                         |
+                         v
+                 REG-SITE-001 / Alpha
+                         |
+                         v
+                 Registry + Warden
+```
+
+## Canonical site roles
+
+- **BC** — governance-and-participation entry surface.
+- **CC** — creator-and-shared-commons surface.
+- **VSR** — front-gate-and-participation-network surface.
+
+These are projections/surfaces. They do not become separate sources of authority or separate identity truths.
+
+## Connection contract
+
+Every site must expose or consume the same minimal federation metadata:
+
+- site id (`bc`, `cc`, `vsr`)
+- canonical URL
+- Alpha node id
+- Registry object (`REG-SITE-001`)
+- Warden authority boundary
+- links to the other two sites
+- central public read-only registry endpoint
+
+Central endpoint:
+
+- `/sites`
+- `/.well-known/estate-sites`
+
+## Identity/session boundary
+
+Do not attempt to preserve DigitalMe continuity by sharing browser cookies across the three top-level domains.
+
+The first slice uses public site federation only. A later authentication slice must use a Warden-issued, short-lived, audience-bound handoff artifact with replay protection and explicit return URL validation.
+
+Therefore:
+
+`SITE NAVIGATION != AUTHORIZATION`
+
+and:
+
+`CROSS-SITE SESSION != SHARED COOKIE`
+
+## Failure rules
+
+1. If the central site registry cannot be reached, each site must retain local static links to the other sites.
+2. A site-registry outage must not prevent the local site from rendering.
+3. A website may request a Warden flow but cannot self-issue authority.
+4. Unknown site ids are rejected rather than guessed.
+5. No site may silently rewrite another site's canonical identity.
+
+## Next slice
+
+After all three source sites carry this contract and their deployments/domains are verified, implement `REG-SITE-HANDOFF-001`:
+
+`DigitalMe -> source site -> Warden handoff grant -> destination site -> replay check -> scoped session -> River evidence`
+
+That handoff is deliberately not part of this public-linking slice.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:compute": "vitest run api/compute-plane.test.ts compute/runtime.test.ts",
     "test:compute-proof": "vitest run compute/runtime.test.ts",
     "test:agent": "vitest run agent-fabric/runtime.test.ts",
+    "test:sites": "vitest run api/sites.test.ts",
     "probe:apple-mpp": "bash scripts/bootstrap-apple-mpp-runner.sh",
     "compile:apple-mpp": "bash native/apple-mpp/build-probe.sh",
     "debug": "mcp-inspector npm start"

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,9 @@
     "api/compute-plane.ts": {
       "maxDuration": 10
     },
+    "api/sites.ts": {
+      "maxDuration": 10
+    },
     "api/mcp.ts": {
       "maxDuration": 60
     },
@@ -26,6 +29,14 @@
     {
       "source": "/compute-plane",
       "destination": "/api/compute-plane"
+    },
+    {
+      "source": "/sites",
+      "destination": "/api/sites"
+    },
+    {
+      "source": "/.well-known/estate-sites",
+      "destination": "/api/sites"
     },
     {
       "source": "/mcp",


### PR DESCRIPTION
## Scope

Connect Believers Common, Creators Common and Virtual Silk Road as one governed estate site family under `ALPHA-NODE-001`, rebased on the current Genesis Agent Fabric head.

## Adds

- `REG-SITE-001` site federation contract.
- `/sites` and `/.well-known/estate-sites` public read-only registry projection.
- Canonical site identities for `bc`, `cc`, `vsr`.
- Warden remains the authority boundary.
- Explicit `NO_SHARED_CROSS_DOMAIN_COOKIE` session rule.
- CORS allow-list for the three canonical sites and Vercel previews.
- Tests for identity, authority, origin and no-shared-cookie invariants.
- Preserves AF-002/AF-003 Agent Fabric scripts and lint scope.

## Boundary

This connects site identities/navigation only. It does not create a cross-site login or authorization bypass. A later `REG-SITE-HANDOFF-001` slice should implement Warden-issued short-lived handoff grants with replay protection.
