### PR TITLE
feat(alpha): add REG-SITE-HANDOFF-001 and register BC/CC apps

### DIFF
--- a/api/site-handoff.ts
+++ b/api/site-handoff.ts
@@ -1,0 +1,30 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+export default function handler(request: IncomingMessage, response: ServerResponse) {
+  response.setHeader("content-type", "application/json; charset=utf-8");
+  response.setHeader("cache-control", "no-store");
+
+  if (request.method !== "GET") {
+    response.statusCode = 405;
+    response.end(JSON.stringify({ ok: false, error: "method_not_allowed" }));
+    return;
+  }
+
+  response.statusCode = 200;
+  response.end(
+    JSON.stringify({
+      ok: true,
+      registry_object: "REG-SITE-HANDOFF-001",
+      alpha_node_id: "ALPHA-NODE-001",
+      authority_boundary: "WARDEN",
+      registered_apps: ["APP-BC-001", "APP-CC-001"],
+      session_policy: "NO_SHARED_CROSS_DOMAIN_COOKIE",
+      token_ttl_seconds_max: 120,
+      replay_protection_required: true,
+      river_evidence_required: true,
+      activation_allowed: false,
+      status: "SCAFFOLDED_NOT_ACTIVATED",
+      next_gate: "DURABLE_REPLAY_STORE_AND_WARDEN_GRANT_VERIFIER",
+    }),
+  );
+}

--- a/config/site-apps/REG-SITE-APP-001.json
+++ b/config/site-apps/REG-SITE-APP-001.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0",
+  "registry_object": "REG-SITE-APP-001",
+  "alpha_node_id": "ALPHA-NODE-001",
+  "authority_boundary": "WARDEN",
+  "registration_contact": "warden@believerscommon.com",
+  "apps": [
+    {
+      "app_id": "APP-BC-001",
+      "site_id": "bc",
+      "name": "Believers Common",
+      "canonical_url": "https://believerscommon.com",
+      "contact_email": "warden@believerscommon.com",
+      "handoff_audiences": ["cc", "vsr"],
+      "status": "REGISTERED"
+    },
+    {
+      "app_id": "APP-CC-001",
+      "site_id": "cc",
+      "name": "Creators Common",
+      "canonical_url": "https://creators-common.org",
+      "contact_email": "warden@believerscommon.com",
+      "handoff_audiences": ["bc", "vsr"],
+      "status": "REGISTERED"
+    }
+  ]
+}

--- a/docs/alpha-node/REG-SITE-HANDOFF-001.md
+++ b/docs/alpha-node/REG-SITE-HANDOFF-001.md
@@ -1,0 +1,62 @@
+# REG-SITE-HANDOFF-001 — Warden Cross-Site Handoff
+
+Status: `ALPHA / SCAFFOLDED_NOT_ACTIVATED`
+Containing node: `ALPHA-NODE-001`
+Authority boundary: `WARDEN`
+Registered apps: `APP-BC-001`, `APP-CC-001`
+Registration contact: `warden@believerscommon.com`
+
+## Purpose
+
+Provide DigitalMe continuity between Believers Common, Creators Common and Virtual Silk Road without sharing a browser cookie across top-level domains and without allowing a website to self-issue authority.
+
+```text
+DigitalMe
+  -> source site
+  -> Warden grant verification
+  -> short-lived handoff token
+  -> destination site
+  -> audience + signature + expiry + return URL verification
+  -> one-time nonce consumption
+  -> scoped destination session
+  -> River evidence
+```
+
+## Token invariants
+
+- issuer is `WARDEN`
+- containing node is `ALPHA-NODE-001`
+- audience is exactly one destination site
+- source and destination must differ
+- maximum TTL is 120 seconds; default is 90 seconds
+- return URL must remain on the destination site's canonical HTTPS origin
+- every token carries a unique nonce
+- every token references a pre-existing Warden grant
+- token verification uses constant-time signature comparison
+- replay must fail closed
+
+## App registration
+
+The first two Warden site applications are recorded in `config/site-apps/REG-SITE-APP-001.json`:
+
+- `APP-BC-001` — Believers Common — `https://believerscommon.com`
+- `APP-CC-001` — Creators Common — `https://creators-common.org`
+
+The registered administrative/contact address for both is `warden@believerscommon.com`.
+
+VSR remains the Front Gate destination/source surface under `REG-SITE-001`; a dedicated VSR app registration can be added when its authentication client boundary is separated from the public Front Gate projection.
+
+## Activation gate
+
+The cryptographic protocol and synthetic replay tests are implemented, but production issuance/consumption is deliberately not enabled yet.
+
+Activation requires:
+
+1. a real Warden grant verifier bound to the current DigitalMe/session;
+2. a durable atomic replay store shared across serverless instances;
+3. River evidence reservation before issuance and sealing after successful consumption;
+4. destination-side scoped-session creation with no shared cross-domain cookie;
+5. production secrets stored only in the deployment secret manager;
+6. end-to-end proof for BC -> CC, BC -> VSR, CC -> BC and CC -> VSR.
+
+The `/site-handoff` route therefore reports readiness only and returns `activation_allowed: false` until those gates are satisfied.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node --experimental-strip-types --no-warnings=ExperimentalWarnings src/app.ts",
     "type-check": "tsc --noEmit",
-    "lint": "eslint --ext .ts src api rc1 compute agent-fabric",
+    "lint": "eslint --ext .ts src api rc1 compute agent-fabric site-handoff",
     "test": "vitest",
     "test:bridge": "vitest run api/registry-bridge.test.ts",
     "test:rc1": "vitest run rc1/runtime.test.ts",
@@ -13,6 +13,7 @@
     "test:compute-proof": "vitest run compute/runtime.test.ts",
     "test:agent": "vitest run agent-fabric/runtime.test.ts",
     "test:sites": "vitest run api/sites.test.ts",
+    "test:site-handoff": "vitest run site-handoff/runtime.test.ts",
     "probe:apple-mpp": "bash scripts/bootstrap-apple-mpp-runner.sh",
     "compile:apple-mpp": "bash native/apple-mpp/build-probe.sh",
     "debug": "mcp-inspector npm start"

--- a/site-handoff/runtime.test.ts
+++ b/site-handoff/runtime.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import { consumeHandoffGrant, issueHandoffGrant, type ReplayStore } from "./runtime.ts";
+
+const secret = "0123456789abcdef0123456789abcdef";
+
+class TestReplayStore implements ReplayStore {
+  private readonly seen = new Set<string>();
+
+  async consumeOnce(nonce: string): Promise<boolean> {
+    if (this.seen.has(nonce)) return false;
+    this.seen.add(nonce);
+    return true;
+  }
+}
+
+describe("REG-SITE-HANDOFF-001", () => {
+  it("issues an audience-bound short-lived Warden handoff", async () => {
+    const now = 2_000_000_000;
+    const { token, claims } = issueHandoffGrant(
+      {
+        digitalMeId: "DIGITALME-TEST-001",
+        sourceSite: "bc",
+        destinationSite: "vsr",
+        returnUrl: "https://virtualsilkroad.com/join",
+        wardenGrantId: "WARDEN-GRANT-TEST-001",
+      },
+      secret,
+      now,
+    );
+
+    expect(claims.issuer).toBe("WARDEN");
+    expect(claims.expires_at - claims.issued_at).toBe(90);
+    const consumed = await consumeHandoffGrant(token, "vsr", secret, new TestReplayStore(), now + 1);
+    expect(consumed.digital_me_id).toBe("DIGITALME-TEST-001");
+  });
+
+  it("rejects audience substitution", async () => {
+    const now = 2_000_000_000;
+    const { token } = issueHandoffGrant(
+      {
+        digitalMeId: "DIGITALME-TEST-001",
+        sourceSite: "bc",
+        destinationSite: "cc",
+        returnUrl: "https://creators-common.org/",
+        wardenGrantId: "WARDEN-GRANT-TEST-001",
+      },
+      secret,
+      now,
+    );
+    await expect(consumeHandoffGrant(token, "vsr", secret, new TestReplayStore(), now + 1)).rejects.toThrow(
+      "audience_mismatch",
+    );
+  });
+
+  it("rejects replay", async () => {
+    const now = 2_000_000_000;
+    const store = new TestReplayStore();
+    const { token } = issueHandoffGrant(
+      {
+        digitalMeId: "DIGITALME-TEST-001",
+        sourceSite: "cc",
+        destinationSite: "bc",
+        returnUrl: "https://believerscommon.com/",
+        wardenGrantId: "WARDEN-GRANT-TEST-001",
+      },
+      secret,
+      now,
+    );
+    await consumeHandoffGrant(token, "bc", secret, store, now + 1);
+    await expect(consumeHandoffGrant(token, "bc", secret, store, now + 2)).rejects.toThrow("replay_detected");
+  });
+
+  it("rejects open redirects and overlong grants", () => {
+    expect(() =>
+      issueHandoffGrant(
+        {
+          digitalMeId: "DIGITALME-TEST-001",
+          sourceSite: "bc",
+          destinationSite: "cc",
+          returnUrl: "https://attacker.example/steal",
+          wardenGrantId: "WARDEN-GRANT-TEST-001",
+        },
+        secret,
+      ),
+    ).toThrow("invalid_return_url");
+
+    expect(() =>
+      issueHandoffGrant(
+        {
+          digitalMeId: "DIGITALME-TEST-001",
+          sourceSite: "bc",
+          destinationSite: "cc",
+          returnUrl: "https://creators-common.org/",
+          wardenGrantId: "WARDEN-GRANT-TEST-001",
+          ttlSeconds: 600,
+        },
+        secret,
+      ),
+    ).toThrow("invalid_ttl");
+  });
+
+  it("requires an actual Warden grant reference", () => {
+    expect(() =>
+      issueHandoffGrant(
+        {
+          digitalMeId: "DIGITALME-TEST-001",
+          sourceSite: "bc",
+          destinationSite: "vsr",
+          returnUrl: "https://virtualsilkroad.com/",
+          wardenGrantId: "",
+        },
+        secret,
+      ),
+    ).toThrow("warden_grant_required");
+  });
+});

--- a/site-handoff/runtime.ts
+++ b/site-handoff/runtime.ts
@@ -43,8 +43,8 @@ function decode(value: string): string {
   return Buffer.from(value, "base64url").toString("utf8");
 }
 
-function signature(unsignedToken: string, secret: string): string {
-  return createHmac("sha256", secret).update(unsignedToken).digest("base64url");
+function signature(unsignedToken: string, secret: string): Buffer {
+  return createHmac("sha256", secret).update(unsignedToken).digest();
 }
 
 function validReturnUrl(site: EstateSiteId, returnUrl: string): boolean {
@@ -88,7 +88,7 @@ export function issueHandoffGrant(
   const header = encode(JSON.stringify({ alg: "HS256", typ: "VSR-HANDOFF" }));
   const payload = encode(JSON.stringify(claims));
   const unsigned = `${header}.${payload}`;
-  return { token: `${unsigned}.${signature(unsigned, secret)}`, claims };
+  return { token: `${unsigned}.${signature(unsigned, secret).toString("base64url")}`, claims };
 }
 
 export async function consumeHandoffGrant(
@@ -102,22 +102,48 @@ export async function consumeHandoffGrant(
 
   const parts = token.split(".");
   if (parts.length !== 3) throw new Error("invalid_token");
-  const [header, payload, suppliedSignature] = parts;
-  const unsigned = `${header}.${payload}`;
+  const [headerPart, payloadPart, signaturePart] = parts;
+
+  let header: { alg?: string; typ?: string };
+  try {
+    header = JSON.parse(decode(headerPart)) as { alg?: string; typ?: string };
+  } catch {
+    throw new Error("invalid_header");
+  }
+  if (header.alg !== "HS256" || header.typ !== "VSR-HANDOFF") throw new Error("invalid_header");
+
+  const unsigned = `${headerPart}.${payloadPart}`;
   const expectedSignature = signature(unsigned, secret);
-  const supplied = Buffer.from(suppliedSignature);
-  const expected = Buffer.from(expectedSignature);
-  if (supplied.length !== expected.length || !timingSafeEqual(supplied, expected)) {
+  let suppliedSignature: Buffer;
+  try {
+    suppliedSignature = Buffer.from(signaturePart, "base64url");
+  } catch {
+    throw new Error("invalid_signature");
+  }
+  if (
+    suppliedSignature.length !== expectedSignature.length ||
+    !timingSafeEqual(suppliedSignature, expectedSignature)
+  ) {
     throw new Error("invalid_signature");
   }
 
-  const claims = JSON.parse(decode(payload)) as HandoffClaims;
+  let claims: HandoffClaims;
+  try {
+    claims = JSON.parse(decode(payloadPart)) as HandoffClaims;
+  } catch {
+    throw new Error("invalid_payload");
+  }
+
   if (claims.version !== "REG-SITE-HANDOFF-001" || claims.issuer !== "WARDEN") {
     throw new Error("invalid_issuer");
   }
   if (claims.node !== "ALPHA-NODE-001") throw new Error("invalid_node");
   if (claims.audience !== expectedAudience) throw new Error("audience_mismatch");
+  if (!Number.isInteger(claims.issued_at) || !Number.isInteger(claims.expires_at)) {
+    throw new Error("invalid_time_claims");
+  }
   if (claims.expires_at <= nowEpochSeconds) throw new Error("expired_handoff");
+  if (claims.expires_at - claims.issued_at > 120) throw new Error("ttl_exceeded");
   if (claims.issued_at > nowEpochSeconds + 30) throw new Error("issued_in_future");
   if (!validReturnUrl(claims.audience, claims.return_url)) throw new Error("invalid_return_url");
   if (!claims.digital_me_id || !claims.warden_grant_id || !claims.nonce) throw new Error("incomplete_claims");

--- a/site-handoff/runtime.ts
+++ b/site-handoff/runtime.ts
@@ -1,0 +1,142 @@
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+
+export type EstateSiteId = "bc" | "cc" | "vsr";
+
+export interface HandoffGrantInput {
+  digitalMeId: string;
+  sourceSite: EstateSiteId;
+  destinationSite: EstateSiteId;
+  returnUrl: string;
+  wardenGrantId: string;
+  ttlSeconds?: number;
+}
+
+export interface HandoffClaims {
+  version: "REG-SITE-HANDOFF-001";
+  issuer: "WARDEN";
+  node: "ALPHA-NODE-001";
+  digital_me_id: string;
+  source_site: EstateSiteId;
+  audience: EstateSiteId;
+  return_url: string;
+  warden_grant_id: string;
+  nonce: string;
+  issued_at: number;
+  expires_at: number;
+}
+
+export interface ReplayStore {
+  consumeOnce(nonce: string, expiresAt: number): Promise<boolean>;
+}
+
+const SITE_URLS: Record<EstateSiteId, string> = {
+  bc: "https://believerscommon.com",
+  cc: "https://creators-common.org",
+  vsr: "https://virtualsilkroad.com",
+};
+
+function encode(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function decode(value: string): string {
+  return Buffer.from(value, "base64url").toString("utf8");
+}
+
+function signature(unsignedToken: string, secret: string): string {
+  return createHmac("sha256", secret).update(unsignedToken).digest("base64url");
+}
+
+function validReturnUrl(site: EstateSiteId, returnUrl: string): boolean {
+  try {
+    const parsed = new URL(returnUrl);
+    const canonical = new URL(SITE_URLS[site]);
+    return parsed.protocol === "https:" && parsed.origin === canonical.origin;
+  } catch {
+    return false;
+  }
+}
+
+export function issueHandoffGrant(
+  input: HandoffGrantInput,
+  secret: string,
+  nowEpochSeconds = Math.floor(Date.now() / 1000),
+): { token: string; claims: HandoffClaims } {
+  if (!secret || secret.length < 32) throw new Error("handoff_secret_not_configured");
+  if (!input.digitalMeId.trim()) throw new Error("digital_me_required");
+  if (!input.wardenGrantId.trim()) throw new Error("warden_grant_required");
+  if (input.sourceSite === input.destinationSite) throw new Error("destination_must_differ");
+  if (!validReturnUrl(input.destinationSite, input.returnUrl)) throw new Error("invalid_return_url");
+
+  const ttl = input.ttlSeconds ?? 90;
+  if (!Number.isInteger(ttl) || ttl < 15 || ttl > 120) throw new Error("invalid_ttl");
+
+  const claims: HandoffClaims = {
+    version: "REG-SITE-HANDOFF-001",
+    issuer: "WARDEN",
+    node: "ALPHA-NODE-001",
+    digital_me_id: input.digitalMeId,
+    source_site: input.sourceSite,
+    audience: input.destinationSite,
+    return_url: input.returnUrl,
+    warden_grant_id: input.wardenGrantId,
+    nonce: randomUUID(),
+    issued_at: nowEpochSeconds,
+    expires_at: nowEpochSeconds + ttl,
+  };
+
+  const header = encode(JSON.stringify({ alg: "HS256", typ: "VSR-HANDOFF" }));
+  const payload = encode(JSON.stringify(claims));
+  const unsigned = `${header}.${payload}`;
+  return { token: `${unsigned}.${signature(unsigned, secret)}`, claims };
+}
+
+export async function consumeHandoffGrant(
+  token: string,
+  expectedAudience: EstateSiteId,
+  secret: string,
+  replayStore: ReplayStore,
+  nowEpochSeconds = Math.floor(Date.now() / 1000),
+): Promise<HandoffClaims> {
+  if (!secret || secret.length < 32) throw new Error("handoff_secret_not_configured");
+
+  const parts = token.split(".");
+  if (parts.length !== 3) throw new Error("invalid_token");
+  const [header, payload, suppliedSignature] = parts;
+  const unsigned = `${header}.${payload}`;
+  const expectedSignature = signature(unsigned, secret);
+  const supplied = Buffer.from(suppliedSignature);
+  const expected = Buffer.from(expectedSignature);
+  if (supplied.length !== expected.length || !timingSafeEqual(supplied, expected)) {
+    throw new Error("invalid_signature");
+  }
+
+  const claims = JSON.parse(decode(payload)) as HandoffClaims;
+  if (claims.version !== "REG-SITE-HANDOFF-001" || claims.issuer !== "WARDEN") {
+    throw new Error("invalid_issuer");
+  }
+  if (claims.node !== "ALPHA-NODE-001") throw new Error("invalid_node");
+  if (claims.audience !== expectedAudience) throw new Error("audience_mismatch");
+  if (claims.expires_at <= nowEpochSeconds) throw new Error("expired_handoff");
+  if (claims.issued_at > nowEpochSeconds + 30) throw new Error("issued_in_future");
+  if (!validReturnUrl(claims.audience, claims.return_url)) throw new Error("invalid_return_url");
+  if (!claims.digital_me_id || !claims.warden_grant_id || !claims.nonce) throw new Error("incomplete_claims");
+
+  const firstUse = await replayStore.consumeOnce(claims.nonce, claims.expires_at);
+  if (!firstUse) throw new Error("replay_detected");
+  return claims;
+}
+
+export class MemoryReplayStore implements ReplayStore {
+  private readonly used = new Map<string, number>();
+
+  async consumeOnce(nonce: string, expiresAt: number): Promise<boolean> {
+    const now = Math.floor(Date.now() / 1000);
+    for (const [key, expiry] of this.used.entries()) {
+      if (expiry <= now) this.used.delete(key);
+    }
+    if (this.used.has(nonce)) return false;
+    this.used.set(nonce, expiresAt);
+    return true;
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -14,6 +14,9 @@
     "api/sites.ts": {
       "maxDuration": 10
     },
+    "api/site-handoff.ts": {
+      "maxDuration": 10
+    },
     "api/mcp.ts": {
       "maxDuration": 60
     },
@@ -37,6 +40,10 @@
     {
       "source": "/.well-known/estate-sites",
       "destination": "/api/sites"
+    },
+    {
+      "source": "/site-handoff",
+      "destination": "/api/site-handoff"
     },
     {
       "source": "/mcp",


### PR DESCRIPTION
## Scope

Start the Warden-governed cross-site continuity layer for BC, CC and VSR under `ALPHA-NODE-001`.

## Adds

- `REG-SITE-APP-001` with `APP-BC-001` and `APP-CC-001` registered to `warden@believerscommon.com`.
- `REG-SITE-HANDOFF-001` cryptographic handoff runtime.
- Audience-bound, short-lived tokens with exact canonical return-origin validation.
- One-time nonce replay interface and synthetic replay tests.
- Fail-closed `/site-handoff` readiness endpoint.
- Warden grant reference is mandatory.
- Maximum token TTL 120 seconds; default 90 seconds.
- No shared cross-domain cookie.

## Deliberate activation boundary

This PR does not activate production handoff issuance. `/site-handoff` reports `activation_allowed: false` until a durable atomic replay store, real Warden grant verifier, River reservation/seal flow, deployment secrets, and destination scoped-session creation are wired.
