### PR TITLE
VSR-NETWORK-CONTRACT-ADAPTER-001 — map RC1 Warden and River into typed contracts

### DIFF
--- a/modules/rc1-adapters.test.ts
+++ b/modules/rc1-adapters.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AlphaRc1Harness,
+  RC1_IDENTITIES,
+} from "../rc1/runtime.ts";
+import type { ActionEnvelopeV1, EffectReceiptV1 } from "./river/contracts.ts";
+import {
+  adaptRc1CausalTrace,
+  adaptRc1EvidenceReservation,
+  adaptRc1EvidenceSeal,
+} from "./river/rc1-adapter.ts";
+import type { WardenDecisionRequestV1 } from "./warden/contracts.ts";
+import {
+  adaptRc1WardenDecision,
+  toRc1ActionIntent,
+} from "./warden/rc1-adapter.ts";
+
+function decisionRequest(
+  action: "service_request.create" | "contract.execute",
+  correlationId: string,
+): WardenDecisionRequestV1 {
+  return {
+    requestRef: `REQUEST:${correlationId}`,
+    actorRef: RC1_IDENTITIES.actorRef,
+    representedPrincipalRef: RC1_IDENTITIES.entityRef,
+    contextRef: RC1_IDENTITIES.programRef,
+    action,
+    targetRef: action === "service_request.create" ? "LAB-SERVICE-DESK-001" : "LAB-CONTRACT-001",
+    authorityRefs: [RC1_IDENTITIES.wardenRef],
+    policyRefs: ["RC1-SYNTHETIC-POLICY"],
+    requestedAt: "2026-08-14T05:30:00.000Z",
+    correlationId,
+  };
+}
+
+describe("RC1 Warden compatibility adapter", () => {
+  it("maps the existing allow decision without changing its action token", () => {
+    const harness = new AlphaRc1Harness();
+    const request = decisionRequest("service_request.create", "ADAPTER-ALLOW-001");
+    const intent = toRc1ActionIntent(request);
+    const result = harness.attempt(intent.capability, intent.correlationId);
+
+    expect(result.status).toBe("VERIFIED");
+    expect(result.decision).toBeDefined();
+    const typed = adaptRc1WardenDecision(request, result.decision!);
+
+    expect(typed.decision).toBe("ALLOW");
+    if (typed.decision !== "ALLOW") throw new Error("expected_allow");
+    expect(typed.actionToken).toBe("RC1-ACTION-TOKEN:ADAPTER-ALLOW-001");
+    expect(typed.reasonCodes).toEqual(["synthetic_rc1_policy_allow"]);
+  });
+
+  it("maps capability denial and post-revocation denial without an action token", () => {
+    const harness = new AlphaRc1Harness();
+    const deniedRequest = decisionRequest("contract.execute", "ADAPTER-DENY-001");
+    const denied = harness.attempt("contract.execute", deniedRequest.correlationId);
+    expect(denied.decision).toBeDefined();
+    const typedDenied = adaptRc1WardenDecision(deniedRequest, denied.decision!);
+
+    expect(typedDenied.decision).toBe("DENY");
+    expect("actionToken" in typedDenied).toBe(false);
+    expect(typedDenied.reasonCodes).toEqual(["capability_not_permitted"]);
+
+    harness.revoke();
+    const revokedRequest = decisionRequest("service_request.create", "ADAPTER-REVOKED-001");
+    const revoked = harness.attempt("service_request.create", revokedRequest.correlationId);
+    expect(revoked.decision).toBeDefined();
+    const typedRevoked = adaptRc1WardenDecision(revokedRequest, revoked.decision!);
+
+    expect(typedRevoked.decision).toBe("DENY");
+    expect("actionToken" in typedRevoked).toBe(false);
+    expect(typedRevoked.reasonCodes).toEqual(["authority_revoked"]);
+  });
+
+  it("rejects actions outside the bounded RC1 capability surface", () => {
+    const request = {
+      ...decisionRequest("service_request.create", "ADAPTER-UNSUPPORTED-001"),
+      action: "bank.transfer",
+    };
+    expect(() => toRc1ActionIntent(request)).toThrow("unsupported_rc1_capability:bank.transfer");
+  });
+});
+
+describe("RC1 River compatibility adapter", () => {
+  it("maps the existing reserve/seal lineage into typed evidence contracts", () => {
+    const harness = new AlphaRc1Harness();
+    const correlationId = "ADAPTER-RIVER-001";
+    const result = harness.attempt("service_request.create", correlationId);
+
+    expect(result.status).toBe("VERIFIED");
+    expect(result.decision).toBeDefined();
+    expect(result.effectRef).toBeDefined();
+
+    const action: ActionEnvelopeV1 = {
+      actionRef: `ACTION:${correlationId}`,
+      actorRef: RC1_IDENTITIES.actorRef,
+      targetRef: "LAB-SERVICE-DESK-001",
+      wardenDecisionRef: result.decision!.decisionRef,
+      requestedAt: "2026-08-14T05:31:00.000Z",
+      correlationId,
+    };
+    const entries = harness.riverEntries();
+    const reservation = adaptRc1EvidenceReservation(action, entries);
+    const effect: EffectReceiptV1 = {
+      effectRef: result.effectRef!,
+      correlationId,
+      targetRef: action.targetRef,
+      observedStateRef: result.receipt!.serviceRequestRef,
+      verifiedAt: "2026-08-14T05:31:01.000Z",
+      verificationRef: `VERIFY:${correlationId}`,
+    };
+    const seal = adaptRc1EvidenceSeal(reservation, effect, entries);
+    const trace = adaptRc1CausalTrace(correlationId, entries);
+
+    expect(reservation.reservationRef).toBe(`RC1-EVIDENCE-RESERVATION:${correlationId}`);
+    expect(seal.sealRef).toBe(`RC1-EVIDENCE-SEALED:${correlationId}`);
+    expect(seal.state).toBe("SEALED");
+    expect(trace.reservationRef).toBe(reservation.reservationRef);
+    expect(trace.effectRef).toBe(effect.effectRef);
+    expect(trace.sealRef).toBe(seal.sealRef);
+    expect(trace.sealed).toBe(true);
+  });
+
+  it("does not manufacture a reservation when the existing River fixture failed", () => {
+    const harness = new AlphaRc1Harness();
+    const correlationId = "ADAPTER-RIVER-FAIL-001";
+    harness.failNextEvidenceReservation();
+    const result = harness.attempt("service_request.create", correlationId);
+
+    expect(result.status).toBe("BLOCKED_REQUIREMENT");
+    const action: ActionEnvelopeV1 = {
+      actionRef: `ACTION:${correlationId}`,
+      actorRef: RC1_IDENTITIES.actorRef,
+      targetRef: "LAB-SERVICE-DESK-001",
+      wardenDecisionRef: result.decision!.decisionRef,
+      requestedAt: "2026-08-14T05:32:00.000Z",
+      correlationId,
+    };
+
+    expect(() => adaptRc1EvidenceReservation(action, harness.riverEntries())).toThrow(
+      "rc1_evidence_reservation_not_found",
+    );
+  });
+});

--- a/modules/river/rc1-adapter.ts
+++ b/modules/river/rc1-adapter.ts
@@ -1,0 +1,88 @@
+import type { Rc1EvidenceEntry } from "../../rc1/runtime.ts";
+import type {
+  ActionEnvelopeV1,
+  CausalTraceV1,
+  EffectReceiptV1,
+  EvidenceReservationV1,
+  EvidenceSealV1,
+} from "./contracts.ts";
+
+function entriesForCorrelation(
+  correlationId: string,
+  entries: readonly Rc1EvidenceEntry[],
+): readonly Rc1EvidenceEntry[] {
+  return entries.filter((entry) => entry.correlationId === correlationId);
+}
+
+export function adaptRc1EvidenceReservation(
+  action: ActionEnvelopeV1,
+  entries: readonly Rc1EvidenceEntry[],
+): EvidenceReservationV1 {
+  const reserved = entriesForCorrelation(action.correlationId, entries).find(
+    (entry) => entry.stage === "RESERVED" && entry.decisionRef === action.wardenDecisionRef,
+  );
+  if (!reserved) {
+    throw new Error("rc1_evidence_reservation_not_found");
+  }
+
+  return {
+    reservationRef: reserved.evidenceRef,
+    actionRef: action.actionRef,
+    correlationId: action.correlationId,
+    state: "RESERVED",
+    reservedAt: action.requestedAt,
+  };
+}
+
+export function adaptRc1EvidenceSeal(
+  reservation: EvidenceReservationV1,
+  effect: EffectReceiptV1,
+  entries: readonly Rc1EvidenceEntry[],
+): EvidenceSealV1 {
+  if (reservation.correlationId !== effect.correlationId) {
+    throw new Error("river_correlation_mismatch");
+  }
+
+  const sealed = entriesForCorrelation(effect.correlationId, entries).find(
+    (entry) => entry.stage === "SEALED" && entry.effectRef === effect.effectRef,
+  );
+  if (!sealed) {
+    throw new Error("rc1_evidence_seal_not_found");
+  }
+
+  return {
+    sealRef: sealed.evidenceRef,
+    reservationRef: reservation.reservationRef,
+    correlationId: effect.correlationId,
+    state: "SEALED",
+    traceDigest: [
+      "RC1-TRACE-V1",
+      reservation.reservationRef,
+      sealed.evidenceRef,
+      effect.effectRef,
+      effect.verificationRef,
+    ].join("|"),
+    sealedAt: effect.verifiedAt,
+  };
+}
+
+export function adaptRc1CausalTrace(
+  correlationId: string,
+  entries: readonly Rc1EvidenceEntry[],
+): CausalTraceV1 {
+  const lineage = entriesForCorrelation(correlationId, entries);
+  const reservation = lineage.find((entry) => entry.stage === "RESERVED");
+  if (!reservation) {
+    throw new Error("rc1_evidence_reservation_not_found");
+  }
+  const seal = lineage.find((entry) => entry.stage === "SEALED");
+
+  return {
+    correlationId,
+    reservationRef: reservation.evidenceRef,
+    eventReceiptRefs: [],
+    effectRef: seal?.effectRef,
+    sealRef: seal?.evidenceRef,
+    sealed: Boolean(seal),
+  };
+}

--- a/modules/warden/rc1-adapter.ts
+++ b/modules/warden/rc1-adapter.ts
@@ -1,0 +1,55 @@
+import type { Rc1ActionIntent, Rc1Capability, Rc1WardenDecision } from "../../rc1/runtime.ts";
+import type {
+  WardenDecisionRequestV1,
+  WardenDecisionV1,
+} from "./contracts.ts";
+
+const RC1_CONSTRAINTS = ["SYNTHETIC_RC1_ONLY"] as const;
+
+function asRc1Capability(action: string): Rc1Capability {
+  if (action === "service_request.create" || action === "contract.execute") {
+    return action;
+  }
+  throw new Error(`unsupported_rc1_capability:${action}`);
+}
+
+export function toRc1ActionIntent(request: WardenDecisionRequestV1): Rc1ActionIntent {
+  if (!request.representedPrincipalRef) {
+    throw new Error("represented_principal_required_for_rc1");
+  }
+
+  return {
+    programRef: request.contextRef,
+    actorRef: request.actorRef,
+    representedEntityRef: request.representedPrincipalRef,
+    capability: asRc1Capability(request.action),
+    correlationId: request.correlationId,
+    targetRef: request.targetRef,
+  };
+}
+
+export function adaptRc1WardenDecision(
+  request: WardenDecisionRequestV1,
+  decision: Rc1WardenDecision,
+): WardenDecisionV1 {
+  const base = {
+    decisionRef: decision.decisionRef,
+    requestRef: request.requestRef,
+    wardenRef: decision.wardenRef,
+    action: request.action,
+    targetRef: request.targetRef,
+    reasonCodes: [decision.reason],
+    constraints: RC1_CONSTRAINTS,
+    decidedAt: request.requestedAt,
+    correlationId: request.correlationId,
+  } as const;
+
+  if (decision.status === "ALLOW") {
+    if (!decision.actionToken) {
+      throw new Error("rc1_allow_missing_action_token");
+    }
+    return { ...base, decision: "ALLOW", actionToken: decision.actionToken };
+  }
+
+  return { ...base, decision: "DENY" };
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:compute-proof": "vitest run compute/runtime.test.ts",
     "test:agent": "vitest run agent-fabric/runtime.test.ts",
     "test:contracts": "vitest run modules/contracts.test.ts",
+    "test:adapters": "vitest run modules/rc1-adapters.test.ts",
     "test:sites": "vitest run api/sites.test.ts",
     "test:site-handoff": "vitest run site-handoff/runtime.test.ts",
     "probe:apple-mpp": "bash scripts/bootstrap-apple-mpp-runner.sh",


### PR DESCRIPTION
## Scope

Stacked follow-up to draft PR #50 and Governance #32.

Adds pure compatibility adapters for the existing RC1 Warden decision and River evidence lineage without changing RC1 runtime behavior.

### Changes
- `modules/warden/rc1-adapter.ts` maps typed Warden requests and existing RC1 decisions into `WardenDecisionV1`;
- `modules/river/rc1-adapter.ts` maps existing RC1 RESERVED/SEALED evidence entries into typed River reservation, seal and causal trace contracts;
- `modules/rc1-adapters.test.ts` characterizes allow, capability deny, revocation deny, unsupported action rejection, reserve/seal mapping and failed-reservation behavior;
- `test:adapters` focused script.

### Design decision
The final implementation is safer than exporting RC1 private fixtures: `rc1/runtime.ts` remains unchanged. The adapters are pure mappers over existing public RC1 decision/evidence outputs. This keeps the current synthetic behavioral lineage intact while proving compatibility with the new typed contracts.

### Verified invariants
- existing RC1 ALLOW preserves its existing action token;
- DENY/revocation outcomes cannot acquire an action token through the adapter;
- unsupported actions fail closed;
- existing RESERVED/SEALED evidence can be reconstructed as typed River contracts;
- a failed reservation cannot be manufactured as `RESERVED`.

### Fresh CI
- test #101: SUCCESS;
- lint #101: SUCCESS;
- type-check #101: SUCCESS;
- bridge-test #27: SUCCESS;
- adapter suite: 5/5 passed;
- full suite: 13 test files / 83 tests passed.

No existing RC1, Agent Fabric, connector/provider, QEL, BNR, SILK Dam or SILK implementation file is modified. Adapter presence does not promote any synthetic service to production.

Governance: Believers-common-group/SynergyzeGovernance#32