### PR TITLE
VSR-NETWORK-QEL-NORMALIZATION-001 — implement deterministic QEL 3 normalization

### DIFF
--- a/.vsr/module-bindings.yaml
+++ b/.vsr/module-bindings.yaml
@@ -54,8 +54,10 @@ modules:
   - module_id: MOD-QEL3-001
     network_object: QEL-3-001
     role: expression-parser-compiler-normalizer
-    state: contract_typed
+    state: conformance_implemented
     intended_path: modules/qel
+    grammar_version: QEL-3.0
+    implementation_file: modules/qel/normalizer.ts
     current_lineage: []
     public_contracts:
       input:
@@ -63,6 +65,7 @@ modules:
       output:
         - NormalizedIntentV1
         - ProgramPlanDraftV1
+        - QelNormalizationResultV1
       type_file: modules/qel/contracts.ts
     depends_on:
       - QEL-GRAMMAR-SPEC
@@ -79,6 +82,7 @@ modules:
     activation_gate: contract-tests-and-compiler-conformance
     tests:
       - modules/contracts.test.ts
+      - modules/qel/normalizer.test.ts
 
   - module_id: MOD-RIVEROS-001
     network_object: RIVEROS-001

--- a/modules/qel/contracts.ts
+++ b/modules/qel/contracts.ts
@@ -6,6 +6,7 @@ export interface QelExpressionRequestV1 {
   sourceRef: string;
   submittedAt: string;
   correlationId: string;
+  grammarVersion?: string;
 }
 
 export interface NormalizedIntentV1 {

--- a/modules/qel/normalizer.test.ts
+++ b/modules/qel/normalizer.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import type { QelExpressionRequestV1 } from "./contracts.ts";
+import { normalizeQelExpressionV1, QEL_3_GRAMMAR_VERSION } from "./normalizer.ts";
+
+function request(overrides: Partial<QelExpressionRequestV1> = {}): QelExpressionRequestV1 {
+  return {
+    expressionRef: "QEL-EXPR-001",
+    rawExpression:
+      "IF ACTOR DIGITALME-ALPHA-TEST-001 IN PLACE ALPHA-NODE-001 ACTS service_request.create ON THING LAB-SERVICE-DESK-001 THEN EFFECT service_request.created USING CAPABILITY service_request.create",
+    actorRef: "DIGITALME-ALPHA-TEST-001",
+    contextRef: "ALPHA-NODE-001",
+    sourceRef: "TEST-VECTOR-001",
+    submittedAt: "2026-08-14T05:45:00.000Z",
+    correlationId: "QEL-CORR-001",
+    grammarVersion: QEL_3_GRAMMAR_VERSION,
+    ...overrides,
+  };
+}
+
+describe("QEL 3 normalization", () => {
+  it("normalizes the canonical Actor/Place/Thing/Effect form without authorization", () => {
+    const result = normalizeQelExpressionV1(request());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.reason);
+
+    expect(result.intent).toMatchObject({
+      actorRef: "DIGITALME-ALPHA-TEST-001",
+      contextRef: "ALPHA-NODE-001",
+      placeRef: "ALPHA-NODE-001",
+      thingRef: "LAB-SERVICE-DESK-001",
+      action: "service_request.create",
+      requestedEffect: "service_request.created",
+      capabilityRef: "service_request.create",
+      authorityState: "UNRESOLVED",
+      authorized: false,
+    });
+    expect(result.plan.status).toBe("DRAFT");
+    expect(result.plan.authorized).toBe(false);
+    expect(result.plan.constraintRefs).toEqual([
+      "QEL_NO_AUTHORIZATION",
+      "QEL_NO_EXECUTION",
+      "QEL_NO_EFFECT_VERIFICATION",
+    ]);
+    expect(result.evidence.grammarVersion).toBe("QEL-3.0");
+    expect(result.evidence.expressionDigest).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  it("is deterministic for the same expression and context", () => {
+    const first = normalizeQelExpressionV1(request());
+    const second = normalizeQelExpressionV1(request());
+
+    expect(first).toEqual(second);
+  });
+
+  it("does not infer a capability when the expression omits it", () => {
+    const result = normalizeQelExpressionV1(
+      request({
+        rawExpression:
+          "IF ACTOR DIGITALME-ALPHA-TEST-001 IN PLACE ALPHA-NODE-001 ACTS inspect ON THING MACHINE-001 THEN EFFECT inspection.requested",
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.reason);
+
+    expect(result.intent.capabilityRef).toBeUndefined();
+    expect(result.plan.steps[0]?.requirementRefs).toContain("CAPABILITY_RESOLUTION_REQUIRED");
+    expect(result.intent.authorized).toBe(false);
+  });
+
+  it("fails closed on actor-reference mismatch", () => {
+    const result = normalizeQelExpressionV1(request({ actorRef: "DIGITALME-OTHER-001" }));
+
+    expect(result).toEqual({
+      ok: false,
+      code: "AMBIGUOUS_REFERENCE",
+      reason: "actor_ref_mismatch",
+      expressionRef: "QEL-EXPR-001",
+      correlationId: "QEL-CORR-001",
+    });
+  });
+
+  it("rejects unsupported grammar versions", () => {
+    const result = normalizeQelExpressionV1(request({ grammarVersion: "QEL-2.0" }));
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "SCHEMA_MISMATCH",
+      reason: "unsupported_grammar_version:QEL-2.0",
+    });
+  });
+
+  it("rejects malformed or unknown trailing syntax rather than guessing", () => {
+    const malformed = normalizeQelExpressionV1(
+      request({
+        rawExpression:
+          "IF ACTOR DIGITALME-ALPHA-TEST-001 AT PLACE ALPHA-NODE-001 ACTS inspect ON THING MACHINE-001 THEN EFFECT inspection.requested",
+      }),
+    );
+    const unknown = normalizeQelExpressionV1(
+      request({
+        rawExpression:
+          "IF ACTOR DIGITALME-ALPHA-TEST-001 IN PLACE ALPHA-NODE-001 ACTS inspect ON THING MACHINE-001 THEN EFFECT inspection.requested MAGIC TOKEN",
+      }),
+    );
+
+    expect(malformed).toMatchObject({ ok: false, code: "PARSE_ERROR" });
+    expect(unknown).toMatchObject({ ok: false, code: "UNKNOWN_SYMBOL" });
+  });
+});

--- a/modules/qel/normalizer.ts
+++ b/modules/qel/normalizer.ts
@@ -1,0 +1,270 @@
+import { createHash } from "node:crypto";
+
+import type {
+  NormalizedIntentV1,
+  ProgramPlanDraftV1,
+  QelExpressionRequestV1,
+} from "./contracts.ts";
+
+export const QEL_3_GRAMMAR_VERSION = "QEL-3.0" as const;
+
+export type QelNormalizationErrorCodeV1 =
+  | "PARSE_ERROR"
+  | "UNKNOWN_SYMBOL"
+  | "AMBIGUOUS_REFERENCE"
+  | "SCHEMA_MISMATCH"
+  | "UNSUPPORTED_EFFECT"
+  | "MISSING_CONTEXT";
+
+export interface QelParseEvidenceV1 {
+  evidenceRef: string;
+  grammarVersion: typeof QEL_3_GRAMMAR_VERSION;
+  canonicalExpression: string;
+  expressionDigest: string;
+  sourceExpressionRef: string;
+  normalizedAt: string;
+  correlationId: string;
+}
+
+export interface QelNormalizationSuccessV1 {
+  ok: true;
+  intent: NormalizedIntentV1;
+  plan: ProgramPlanDraftV1;
+  evidence: QelParseEvidenceV1;
+}
+
+export interface QelNormalizationFailureV1 {
+  ok: false;
+  code: QelNormalizationErrorCodeV1;
+  reason: string;
+  expressionRef: string;
+  correlationId: string;
+}
+
+export type QelNormalizationResultV1 =
+  | QelNormalizationSuccessV1
+  | QelNormalizationFailureV1;
+
+interface ParsedQelExpressionV1 {
+  actorRef: string;
+  placeRef: string;
+  action: string;
+  thingRef: string;
+  requestedEffect: string;
+  capabilityRef?: string;
+}
+
+const REQUIRED_SEQUENCE = [
+  "IF",
+  "ACTOR",
+  "IN",
+  "PLACE",
+  "ACTS",
+  "ON",
+  "THING",
+  "THEN",
+  "EFFECT",
+] as const;
+
+function digest(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function canonicalize(parsed: ParsedQelExpressionV1): string {
+  const capability = parsed.capabilityRef
+    ? ` USING CAPABILITY ${parsed.capabilityRef}`
+    : "";
+
+  return [
+    "IF ACTOR",
+    parsed.actorRef,
+    "IN PLACE",
+    parsed.placeRef,
+    "ACTS",
+    parsed.action,
+    "ON THING",
+    parsed.thingRef,
+    "THEN EFFECT",
+    parsed.requestedEffect,
+  ].join(" ") + capability;
+}
+
+function parse(rawExpression: string):
+  | { ok: true; value: ParsedQelExpressionV1 }
+  | { ok: false; code: QelNormalizationErrorCodeV1; reason: string } {
+  const tokens = rawExpression.trim().split(/\s+/).filter(Boolean);
+
+  if (tokens.length === 0) {
+    return { ok: false, code: "MISSING_CONTEXT", reason: "expression_empty" };
+  }
+
+  if (tokens.length < 14) {
+    return { ok: false, code: "PARSE_ERROR", reason: "expression_incomplete" };
+  }
+
+  const expectedKeywords: Array<[number, string]> = [
+    [0, REQUIRED_SEQUENCE[0]],
+    [1, REQUIRED_SEQUENCE[1]],
+    [3, REQUIRED_SEQUENCE[2]],
+    [4, REQUIRED_SEQUENCE[3]],
+    [6, REQUIRED_SEQUENCE[4]],
+    [8, REQUIRED_SEQUENCE[5]],
+    [9, REQUIRED_SEQUENCE[6]],
+    [11, REQUIRED_SEQUENCE[7]],
+    [12, REQUIRED_SEQUENCE[8]],
+  ];
+
+  for (const [index, expected] of expectedKeywords) {
+    if (tokens[index] !== expected) {
+      return {
+        ok: false,
+        code: "PARSE_ERROR",
+        reason: `expected_${expected.toLowerCase()}_at_token_${index}`,
+      };
+    }
+  }
+
+  const base: ParsedQelExpressionV1 = {
+    actorRef: tokens[2],
+    placeRef: tokens[5],
+    action: tokens[7],
+    thingRef: tokens[10],
+    requestedEffect: tokens[13],
+  };
+
+  if (!base.actorRef || !base.placeRef || !base.action || !base.thingRef || !base.requestedEffect) {
+    return { ok: false, code: "MISSING_CONTEXT", reason: "required_qel_reference_missing" };
+  }
+
+  if (tokens.length === 14) {
+    return { ok: true, value: base };
+  }
+
+  if (tokens.length === 17 && tokens[14] === "USING" && tokens[15] === "CAPABILITY") {
+    if (!tokens[16]) {
+      return { ok: false, code: "MISSING_CONTEXT", reason: "capability_ref_missing" };
+    }
+    return { ok: true, value: { ...base, capabilityRef: tokens[16] } };
+  }
+
+  return {
+    ok: false,
+    code: "UNKNOWN_SYMBOL",
+    reason: `unsupported_trailing_tokens:${tokens.slice(14).join(" ")}`,
+  };
+}
+
+export function normalizeQelExpressionV1(
+  request: QelExpressionRequestV1,
+): QelNormalizationResultV1 {
+  const grammarVersion = request.grammarVersion ?? QEL_3_GRAMMAR_VERSION;
+  if (grammarVersion !== QEL_3_GRAMMAR_VERSION) {
+    return {
+      ok: false,
+      code: "SCHEMA_MISMATCH",
+      reason: `unsupported_grammar_version:${grammarVersion}`,
+      expressionRef: request.expressionRef,
+      correlationId: request.correlationId,
+    };
+  }
+
+  if (!request.actorRef || !request.contextRef || !request.sourceRef) {
+    return {
+      ok: false,
+      code: "MISSING_CONTEXT",
+      reason: "request_context_incomplete",
+      expressionRef: request.expressionRef,
+      correlationId: request.correlationId,
+    };
+  }
+
+  const parsed = parse(request.rawExpression);
+  if (!parsed.ok) {
+    return {
+      ok: false,
+      code: parsed.code,
+      reason: parsed.reason,
+      expressionRef: request.expressionRef,
+      correlationId: request.correlationId,
+    };
+  }
+
+  if (parsed.value.actorRef !== request.actorRef) {
+    return {
+      ok: false,
+      code: "AMBIGUOUS_REFERENCE",
+      reason: "actor_ref_mismatch",
+      expressionRef: request.expressionRef,
+      correlationId: request.correlationId,
+    };
+  }
+
+  const canonicalExpression = canonicalize(parsed.value);
+  const expressionDigest = `sha256:${digest(canonicalExpression)}`;
+  const identitySeed = digest(
+    [request.expressionRef, canonicalExpression, request.contextRef, request.correlationId].join("|"),
+  ).slice(0, 20);
+
+  const intentRef = `QEL-INTENT:${identitySeed}`;
+  const planRef = `QEL-PLAN:${identitySeed}`;
+  const stepRef = `QEL-STEP:${identitySeed}:001`;
+  const evidenceRef = `QEL-PARSE-EVIDENCE:${identitySeed}`;
+
+  const intent: NormalizedIntentV1 = {
+    intentRef,
+    actorRef: parsed.value.actorRef,
+    contextRef: request.contextRef,
+    placeRef: parsed.value.placeRef,
+    thingRef: parsed.value.thingRef,
+    action: parsed.value.action,
+    requestedEffect: parsed.value.requestedEffect,
+    capabilityRef: parsed.value.capabilityRef,
+    authorityState: "UNRESOLVED",
+    authorized: false,
+    sourceExpressionRef: request.expressionRef,
+    correlationId: request.correlationId,
+  };
+
+  const requirementRefs = [
+    "WARDEN_EVALUATION_REQUIRED",
+    "AUTHORITY_RESOLUTION_REQUIRED",
+  ];
+  if (!parsed.value.capabilityRef) {
+    requirementRefs.push("CAPABILITY_RESOLUTION_REQUIRED");
+  }
+
+  const plan: ProgramPlanDraftV1 = {
+    planRef,
+    intentRef,
+    status: "DRAFT",
+    authorized: false,
+    steps: [
+      {
+        stepRef,
+        action: parsed.value.action,
+        targetRef: parsed.value.thingRef,
+        dependencyRefs: [parsed.value.placeRef],
+        requirementRefs,
+      },
+    ],
+    dependencyRefs: [parsed.value.placeRef, parsed.value.thingRef],
+    constraintRefs: [
+      "QEL_NO_AUTHORIZATION",
+      "QEL_NO_EXECUTION",
+      "QEL_NO_EFFECT_VERIFICATION",
+    ],
+    correlationId: request.correlationId,
+  };
+
+  const evidence: QelParseEvidenceV1 = {
+    evidenceRef,
+    grammarVersion: QEL_3_GRAMMAR_VERSION,
+    canonicalExpression,
+    expressionDigest,
+    sourceExpressionRef: request.expressionRef,
+    normalizedAt: request.submittedAt,
+    correlationId: request.correlationId,
+  };
+
+  return { ok: true, intent, plan, evidence };
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:agent": "vitest run agent-fabric/runtime.test.ts",
     "test:contracts": "vitest run modules/contracts.test.ts",
     "test:adapters": "vitest run modules/rc1-adapters.test.ts",
+    "test:qel": "vitest run modules/qel/normalizer.test.ts",
     "test:sites": "vitest run api/sites.test.ts",
     "test:site-handoff": "vitest run site-handoff/runtime.test.ts",
     "probe:apple-mpp": "bash scripts/bootstrap-apple-mpp-runner.sh",


### PR DESCRIPTION
## Scope

Stacked follow-up to PR #51 and Governance #33.

Implements the first bounded QEL-3 normalization/compiler surface.

### Canonical grammar
`IF ACTOR <actorRef> IN PLACE <placeRef> ACTS <action> ON THING <thingRef> THEN EFFECT <effect> [USING CAPABILITY <capabilityRef>]`

### Implementation
- deterministic parser/normalizer in `modules/qel/normalizer.ts`;
- stable canonical expression + SHA-256 parse evidence;
- `NormalizedIntentV1` always keeps `authorityState: UNRESOLVED` and `authorized: false`;
- draft Program plan only, with explicit Warden/authority requirements;
- omitted capability remains unresolved rather than inferred;
- malformed syntax, unknown trailing tokens, actor mismatch and grammar mismatch fail closed;
- `.vsr/module-bindings.yaml` now records QEL-3.0 as `conformance_implemented`, not active.

### Verified invariants
- QEL cannot issue an action token;
- QEL cannot authorize;
- QEL cannot execute a connector;
- QEL cannot mark a requested effect verified;
- missing capability is surfaced as `CAPABILITY_RESOLUTION_REQUIRED`;
- identical input/context produces identical intent/plan/evidence IDs and digest.

### Fresh CI on final head `ed0dcad27d3ef8c8179762ed7e099700eabd894f`
- test #106: SUCCESS;
- lint #106: SUCCESS;
- type-check #106: SUCCESS;
- bridge-test #31: SUCCESS;
- QEL normalizer suite: 6/6 passed;
- full suite: 14 test files / 89 tests passed.

### Diff scope
5 commits, 5 changed files, 0 behind stacked base PR #51. No Warden, River RC1, Agent Fabric, connector/provider, BNR, SILK Dam or SILK implementation behavior was modified.

Conformance implementation does not imply release-candidate, authorization-ready, authorized or active state.