### PR TITLE
ALPHA-OBJ-RUNTIME-001 — governed Objective inventory-transfer proof

### DIFF
--- a/.vsr/repository-components.yaml
+++ b/.vsr/repository-components.yaml
@@ -8,8 +8,10 @@ canonical_governance:
     - issue:13
     - issue:34
     - issue:35
+    - issue:36
     - issue:38
     - issue:39
+    - issue:40
     - issue:41
 
 components:
@@ -213,4 +215,73 @@ components:
       - modules/synnergyze/effect-verification.test.ts
     downstream_boundary: river-seal-to-registry-effect-to-objective-acceptance
     activation_gate: post-execution-observation-and-effect-verification-conformance-only
+    activation_implied: false
+
+  - component_id: CMP-SYNNERGYZE-OBJECTIVE-INVENTORY-001
+    network_object: SYNNERGYZE-RUNTIME-001
+    role: governed-objective-to-synthetic-inventory-transfer-acceptance
+    state: conformance_implemented
+    implementation_path: modules/objective/inventory-transfer.ts
+    contract_paths:
+      - modules/objective/contracts.ts
+      - modules/warden/contracts.ts
+      - modules/river/contracts.ts
+      - modules/synnergyze/contracts.ts
+      - modules/synnergyze/effect-verification.ts
+    purpose_lineage:
+      - PRINCIPAL
+      - OBJECTIVE
+      - AUTHORITY
+      - PROGRAM
+      - EVENT
+      - EXECUTION
+      - EVIDENCE
+      - EFFECT
+      - ACCEPTANCE
+    input_contracts:
+      - ObjectiveRefV1
+      - ObjectiveAuthorityEnvelopeV1
+      - InventoryTransferSpecV1
+    output_contracts:
+      - ObjectiveProgramBundleV1
+      - ObjectiveEffectV1
+      - AcceptanceResultV1
+      - InventoryTransferProofV1
+    depends_on:
+      - CMP-SYNNERGYZE-CONTROLLED-EXECUTION-001
+      - CMP-SYNNERGYZE-EFFECT-VERIFY-001
+      - WARDEN-RUNTIME-001
+      - RIVEROS-001
+    capability_allowlist:
+      - inventory.transfer
+    required_guards:
+      - objective-authorized-and-in-window
+      - explicit-principal-actor-capacity-context
+      - explicit-resource-scope
+      - fresh-warden-action-decision
+      - river-reservation-before-execution
+      - fresh-warden-execution-checkpoint
+      - post-execution-read-after-write-observation
+      - effect-verification-before-river-seal
+      - river-seal-before-objective-effect-record
+      - purpose-lineage-on-every-program-event-effect
+      - duplicate-effect-rejection
+      - front-back-projection-equivalence
+      - acceptance-only-from-observed-sealed-effects
+    forbidden:
+      - infer-objective-authority-from-model-or-agent
+      - infer-effect-from-intended-outcome
+      - accept-without-sealed-evidence
+      - duplicate-effect-on-replay
+      - provider-or-database-authority
+      - real-external-inventory-write
+      - create-financial-or-legal-effect
+      - create-economic-obligation
+      - imply-settlement-finality
+      - activate-real-location-canary
+    tests:
+      - modules/objective/inventory-transfer.test.ts
+      - modules/synnergyze/execution-gate.test.ts
+      - modules/synnergyze/effect-verification.test.ts
+    activation_gate: synthetic-objective-proof-only-real-canary-separately-authorized
     activation_implied: false

--- a/modules/objective/contracts.ts
+++ b/modules/objective/contracts.ts
@@ -32,11 +32,15 @@ export interface ObjectiveAuthorityEnvelopeV1 {
   objectiveRef: string;
   principalRef: string;
   actorRef: string;
+  actingCapacityRef: string;
+  contextRef: string;
   wardenRef: string;
   wardenDecisionRef: string;
   decision: "ALLOW" | "ESCALATE" | "DENY";
   state: "ACTIVE" | "EXPIRED" | "REVOKED" | "SUPERSEDED";
   allowedCapabilityRefs: readonly string[];
+  resourceRefs: readonly string[];
+  evidenceRequirementRefs: readonly string[];
   validFrom: string;
   validUntil: string;
   constraintRefs: readonly string[];

--- a/modules/objective/contracts.ts
+++ b/modules/objective/contracts.ts
@@ -1,0 +1,145 @@
+export type ObjectiveLifecycleStateV1 =
+  | "DRAFT"
+  | "PROPOSED"
+  | "AUTHORITY_PENDING"
+  | "AUTHORIZED"
+  | "ACTIVE"
+  | "ACCEPTANCE_PENDING"
+  | "ACCEPTED"
+  | "FAILED"
+  | "CANCELLED"
+  | "SUPERSEDED"
+  | "CLOSED";
+
+export interface ObjectiveRefV1 {
+  objectiveRef: string;
+  principalRef: string;
+  statementRef: string;
+  desiredStateRef: string;
+  successConditionRefs: readonly string[];
+  constraintRefs: readonly string[];
+  authorityRequirementRefs: readonly string[];
+  acceptanceProfileRef: string;
+  validFrom: string;
+  validUntil: string;
+  version: string;
+  status: ObjectiveLifecycleStateV1;
+  supersedesRef?: string;
+}
+
+export interface ObjectiveAuthorityEnvelopeV1 {
+  authorityRef: string;
+  objectiveRef: string;
+  principalRef: string;
+  actorRef: string;
+  wardenRef: string;
+  wardenDecisionRef: string;
+  decision: "ALLOW" | "ESCALATE" | "DENY";
+  state: "ACTIVE" | "EXPIRED" | "REVOKED" | "SUPERSEDED";
+  allowedCapabilityRefs: readonly string[];
+  validFrom: string;
+  validUntil: string;
+  constraintRefs: readonly string[];
+}
+
+export interface InventoryTransferSpecV1 {
+  sourceLocationRef: string;
+  destinationLocationRef: string;
+  skuRef: string;
+  quantity: number;
+}
+
+export interface ObjectiveProgramV1 {
+  programRef: string;
+  objectiveRef: string;
+  objectiveVersion: string;
+  purposeLineageRef: string;
+  principalRef: string;
+  actorRef: string;
+  authorityRef: string;
+  correlationId: string;
+  eventRefs: readonly string[];
+  transfer: InventoryTransferSpecV1;
+}
+
+export interface ObjectiveEventV1 {
+  eventRef: string;
+  eventType:
+    | "RESOLVE_OBJECTIVE"
+    | "RESOLVE_RESOURCES"
+    | "PREPARE_TRANSFER"
+    | "WARDEN_ALLOW"
+    | "RESERVE_EVIDENCE"
+    | "DISPATCH"
+    | "VERIFY_DISPATCH"
+    | "RECEIVE"
+    | "VERIFY_RECEIPT"
+    | "SEAL_EVIDENCE"
+    | "RECORD_EFFECTS"
+    | "ACCEPTANCE_CHECK"
+    | "RECONCILE_PROJECTIONS"
+    | "CLOSE_OBJECTIVE";
+  sequence: number;
+  objectiveRef: string;
+  programRef: string;
+  authorityRef: string;
+  correlationId: string;
+  idempotencyKey: string;
+  capabilityRef?: string;
+  targetRef?: string;
+  expectedEffectRefs: readonly string[];
+  requiredEvidenceRefs: readonly string[];
+}
+
+export interface ObjectiveProgramBundleV1 {
+  program: ObjectiveProgramV1;
+  events: readonly ObjectiveEventV1[];
+}
+
+export interface ObjectiveEffectV1 {
+  effectRef: string;
+  objectiveRef: string;
+  programRef: string;
+  eventRef: string;
+  subjectRef: string;
+  observedDeltaOrStateRef: string;
+  evidenceRef: string;
+  verifiedEffectRef: string;
+  classification: "intended" | "unintended" | "neutral" | "adverse";
+  acceptanceRelevance: "REQUIRED" | "SUPPORTING" | "NONE";
+  observedAt: string;
+}
+
+export interface ObjectiveProjectionV1 {
+  objectiveRef: string;
+  status: ObjectiveLifecycleStateV1;
+  programRef: string;
+  authorityRef: string;
+  effectRefs: readonly string[];
+  evidenceRefs: readonly string[];
+  sourceQuantity: number;
+  destinationQuantity: number;
+}
+
+export interface AcceptanceResultV1 {
+  objectiveRef: string;
+  profileRef: string;
+  result: "PASS" | "FAIL" | "PARTIAL" | "ESCALATE";
+  checkedEffectRefs: readonly string[];
+  checkedEvidenceRefs: readonly string[];
+  checkedAt: string;
+  reasonCodes: readonly string[];
+}
+
+export interface InventoryTransferProofV1 {
+  objective: ObjectiveRefV1;
+  authority: ObjectiveAuthorityEnvelopeV1;
+  bundle: ObjectiveProgramBundleV1;
+  verifiedEffectRef: string;
+  riverSealRef: string;
+  effects: readonly ObjectiveEffectV1[];
+  frontProjection: ObjectiveProjectionV1;
+  backProjection: ObjectiveProjectionV1;
+  acceptance: AcceptanceResultV1;
+  closedObjective: ObjectiveRefV1;
+}

--- a/modules/objective/inventory-transfer.test.ts
+++ b/modules/objective/inventory-transfer.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "vitest";
+
+import type { EvidenceSealV1 } from "../river/contracts.ts";
+import type {
+  InventoryTransferSpecV1,
+  ObjectiveAuthorityEnvelopeV1,
+  ObjectiveProjectionV1,
+  ObjectiveRefV1,
+} from "./contracts.ts";
+import {
+  compileInventoryTransferObjective,
+  evaluateInventoryTransferAcceptance,
+  InMemoryInventoryLedgerV1,
+  observeInventoryTransfer,
+  runSyntheticInventoryTransferProof,
+  type SyntheticInventoryTransferTimelineV1,
+} from "./inventory-transfer.ts";
+
+const transfer: InventoryTransferSpecV1 = {
+  sourceLocationRef: "LOC-ALPHA-SRC-001",
+  destinationLocationRef: "LOC-ALPHA-DST-001",
+  skuRef: "SKU-ALPHA-001",
+  quantity: 10,
+};
+
+function objective(overrides: Partial<ObjectiveRefV1> = {}): ObjectiveRefV1 {
+  return {
+    objectiveRef: "OBJ-ALPHA-STOCK-001",
+    principalRef: "LAB-COMPANY-001",
+    statementRef: "STATEMENT:PREVENT-AVAILABILITY-FAILURE",
+    desiredStateRef: "DESIRED:SKU-ALPHA-001-AVAILABLE-AT-DST",
+    successConditionRefs: ["SUCCESS:SOURCE-MINUS-10", "SUCCESS:DESTINATION-PLUS-10"],
+    constraintRefs: ["SYNTHETIC_ONLY", "NO_EXTERNAL_PROVIDER"],
+    authorityRequirementRefs: ["POLICY:ALPHA-OBJECTIVE-001"],
+    acceptanceProfileRef: "ACCEPTANCE:ALPHA-STOCK-TRANSFER-001",
+    validFrom: "2026-08-15T05:00:00.000Z",
+    validUntil: "2026-08-15T06:00:00.000Z",
+    version: "1.0.0",
+    status: "AUTHORIZED",
+    ...overrides,
+  };
+}
+
+function authority(overrides: Partial<ObjectiveAuthorityEnvelopeV1> = {}): ObjectiveAuthorityEnvelopeV1 {
+  return {
+    authorityRef: "OBJECTIVE-AUTHORITY:OBJ-ALPHA-STOCK-001",
+    objectiveRef: "OBJ-ALPHA-STOCK-001",
+    principalRef: "LAB-COMPANY-001",
+    actorRef: "DIGITALME-ALPHA-TEST-001",
+    actingCapacityRef: "CAPACITY:LAB-OPERATOR-001",
+    contextRef: "ALPHA-NODE-001",
+    wardenRef: "WARDEN-ALPHA-RC1-001",
+    wardenDecisionRef: "WARDEN-OBJECTIVE-DECISION:OBJ-ALPHA-STOCK-001",
+    decision: "ALLOW",
+    state: "ACTIVE",
+    allowedCapabilityRefs: ["inventory.transfer"],
+    resourceRefs: ["LOC-ALPHA-SRC-001", "LOC-ALPHA-DST-001", "SKU-ALPHA-001"],
+    evidenceRequirementRefs: ["EVIDENCE:DISPATCH", "EVIDENCE:RECEIPT"],
+    validFrom: "2026-08-15T05:00:00.000Z",
+    validUntil: "2026-08-15T06:00:00.000Z",
+    constraintRefs: ["SYNTHETIC_ONLY", "NO_FINANCIAL_EFFECT"],
+    ...overrides,
+  };
+}
+
+const timeline: SyntheticInventoryTransferTimelineV1 = {
+  compiledAt: "2026-08-15T05:10:00.000Z",
+  actionRequestedAt: "2026-08-15T05:10:01.000Z",
+  decidedAt: "2026-08-15T05:10:02.000Z",
+  reservedAt: "2026-08-15T05:10:03.000Z",
+  checkpointAt: "2026-08-15T05:10:04.000Z",
+  executedAt: "2026-08-15T05:10:05.000Z",
+  observedAt: "2026-08-15T05:10:06.000Z",
+  verifiedAt: "2026-08-15T05:10:07.000Z",
+  sealedAt: "2026-08-15T05:10:08.000Z",
+  acceptedAt: "2026-08-15T05:10:09.000Z",
+};
+
+describe("ALPHA-OBJ-RUNTIME-001", () => {
+  it("compiles the 14-event Objective plan with purpose and authority lineage on every event", () => {
+    const bundle = compileInventoryTransferObjective({
+      objective: objective(),
+      authority: authority(),
+      transfer,
+      compiledAt: timeline.compiledAt,
+    });
+
+    expect(bundle.events).toHaveLength(14);
+    expect(bundle.events.map((event) => event.eventType)).toEqual([
+      "RESOLVE_OBJECTIVE",
+      "RESOLVE_RESOURCES",
+      "PREPARE_TRANSFER",
+      "WARDEN_ALLOW",
+      "RESERVE_EVIDENCE",
+      "DISPATCH",
+      "VERIFY_DISPATCH",
+      "RECEIVE",
+      "VERIFY_RECEIPT",
+      "SEAL_EVIDENCE",
+      "RECORD_EFFECTS",
+      "ACCEPTANCE_CHECK",
+      "RECONCILE_PROJECTIONS",
+      "CLOSE_OBJECTIVE",
+    ]);
+    for (const event of bundle.events) {
+      expect(event.objectiveRef).toBe("OBJ-ALPHA-STOCK-001");
+      expect(event.programRef).toBe(bundle.program.programRef);
+      expect(event.authorityRef).toBe(authority().authorityRef);
+      expect(event.correlationId).toBe(bundle.program.correlationId);
+      expect(event.idempotencyKey).toBeTruthy();
+    }
+    expect(bundle.program.objectiveRef).toBe("OBJ-ALPHA-STOCK-001");
+    expect(bundle.program.purposeLineageRef).toMatch(/^PURPOSE-LINEAGE:/);
+  });
+
+  it("executes exactly one synthetic transfer and closes only after observed, verified, sealed effects pass acceptance", () => {
+    const proof = runSyntheticInventoryTransferProof({
+      objective: objective(),
+      authority: authority(),
+      transfer,
+      sourceInitial: 50,
+      destinationInitial: 5,
+      timeline,
+    });
+
+    expect(proof.effects).toHaveLength(2);
+    expect(proof.effects.map((effect) => effect.observedDeltaOrStateRef)).toEqual(["DELTA:-10", "DELTA:+10"]);
+    expect(proof.effects.every((effect) => effect.objectiveRef === "OBJ-ALPHA-STOCK-001")).toBe(true);
+    expect(proof.effects.every((effect) => effect.evidenceRef === proof.riverSealRef)).toBe(true);
+    expect(proof.verifiedEffectRef).toMatch(/^VERIFIED-EFFECT:/);
+    expect(proof.riverSealRef).toMatch(/^OBJECTIVE-RIVER-SEAL:/);
+    expect(proof.frontProjection).toEqual(proof.backProjection);
+    expect(proof.frontProjection.sourceQuantity).toBe(40);
+    expect(proof.frontProjection.destinationQuantity).toBe(15);
+    expect(proof.acceptance.result).toBe("PASS");
+    expect(proof.closedObjective.status).toBe("CLOSED");
+    expect("settlementRef" in proof).toBe(false);
+    expect("economicObligationRef" in proof).toBe(false);
+  });
+
+  it("fails before planning/execution when Objective authority is denied, revoked, expired or lacks resource scope", () => {
+    const invalidAuthorities: ObjectiveAuthorityEnvelopeV1[] = [
+      authority({ decision: "DENY" }),
+      authority({ state: "REVOKED" }),
+      authority({ state: "EXPIRED" }),
+      authority({ resourceRefs: ["LOC-ALPHA-SRC-001", "SKU-ALPHA-001"] }),
+    ];
+    for (const invalid of invalidAuthorities) {
+      expect(() =>
+        compileInventoryTransferObjective({ objective: objective(), authority: invalid, transfer, compiledAt: timeline.compiledAt }),
+      ).toThrow();
+    }
+  });
+
+  it("fails closed when authority or Objective validity has expired", () => {
+    expect(() =>
+      compileInventoryTransferObjective({
+        objective: objective(),
+        authority: authority({ validUntil: "2026-08-15T05:09:59.000Z" }),
+        transfer,
+        compiledAt: timeline.compiledAt,
+      }),
+    ).toThrow("objective_authority_outside_validity_window");
+    expect(() =>
+      compileInventoryTransferObjective({
+        objective: objective({ validUntil: "2026-08-15T05:09:59.000Z" }),
+        authority: authority(),
+        transfer,
+        compiledAt: timeline.compiledAt,
+      }),
+    ).toThrow("objective_outside_validity_window");
+  });
+
+  it("refuses to fabricate observed Effects when read-after-write state does not match the transfer", () => {
+    const ledger = new InMemoryInventoryLedgerV1();
+    ledger.set(transfer.sourceLocationRef, transfer.skuRef, 41);
+    ledger.set(transfer.destinationLocationRef, transfer.skuRef, 15);
+    expect(() =>
+      observeInventoryTransfer({
+        receipt: {
+          receiptRef: "EXECUTION:TEST",
+          actionRef: "ACTION:TEST",
+          programRef: "PROGRAM:TEST",
+          eventRef: "EVENT:TEST",
+          targetRef: "TARGET:TEST",
+          correlationId: "CORR:TEST",
+          executedAt: timeline.executedAt,
+        },
+        ledger,
+        transfer,
+        sourcePrior: 50,
+        destinationPrior: 5,
+        observedAt: timeline.observedAt,
+      }),
+    ).toThrow("inventory_read_after_write_mismatch");
+  });
+
+  it("acceptance fails on projection divergence even when Effects and evidence otherwise match", () => {
+    const proof = runSyntheticInventoryTransferProof({
+      objective: objective(),
+      authority: authority(),
+      transfer,
+      sourceInitial: 50,
+      destinationInitial: 5,
+      timeline,
+    });
+    const seal: EvidenceSealV1 = {
+      sealRef: proof.riverSealRef,
+      reservationRef: "RESERVATION:TEST",
+      correlationId: proof.bundle.program.correlationId,
+      state: "SEALED",
+      traceDigest: "TRACE",
+      sealedAt: timeline.sealedAt,
+    };
+    const divergentBack: ObjectiveProjectionV1 = {
+      ...proof.backProjection,
+      destinationQuantity: proof.backProjection.destinationQuantity + 1,
+    };
+    const result = evaluateInventoryTransferAcceptance({
+      objective: objective({ status: "ACCEPTANCE_PENDING" }),
+      transfer,
+      effects: proof.effects,
+      seal,
+      frontProjection: proof.frontProjection,
+      backProjection: divergentBack,
+      checkedAt: timeline.acceptedAt,
+    });
+    expect(result.result).toBe("FAIL");
+    expect(result.reasonCodes).toContain("PROJECTION_DIVERGENCE");
+  });
+
+  it("acceptance rejects duplicate Effects and unsealed/mismatched evidence", () => {
+    const proof = runSyntheticInventoryTransferProof({
+      objective: objective(),
+      authority: authority(),
+      transfer,
+      sourceInitial: 50,
+      destinationInitial: 5,
+      timeline,
+    });
+    const seal: EvidenceSealV1 = {
+      sealRef: "SEAL:OTHER",
+      reservationRef: "RESERVATION:TEST",
+      correlationId: proof.bundle.program.correlationId,
+      state: "SEALED",
+      traceDigest: "TRACE",
+      sealedAt: timeline.sealedAt,
+    };
+    const duplicated = [proof.effects[0], proof.effects[0]];
+    const result = evaluateInventoryTransferAcceptance({
+      objective: objective({ status: "ACCEPTANCE_PENDING" }),
+      transfer,
+      effects: duplicated,
+      seal,
+      frontProjection: proof.frontProjection,
+      backProjection: proof.backProjection,
+      checkedAt: timeline.acceptedAt,
+    });
+    expect(result.result).toBe("FAIL");
+    expect(result.reasonCodes).toContain("DUPLICATE_EFFECT");
+    expect(result.reasonCodes).toContain("EFFECT_EVIDENCE_MISMATCH");
+  });
+
+  it("keeps model/provider identity outside Objective ownership and authority lineage", () => {
+    const firstModel = "MODEL-BINDING-A-001";
+    const secondModel = "MODEL-BINDING-B-001";
+    const first = compileInventoryTransferObjective({ objective: objective(), authority: authority(), transfer, compiledAt: timeline.compiledAt });
+    const second = compileInventoryTransferObjective({ objective: objective(), authority: authority(), transfer, compiledAt: timeline.compiledAt });
+    expect(first.program.objectiveRef).toBe(second.program.objectiveRef);
+    expect(first.program.authorityRef).toBe(second.program.authorityRef);
+    expect(first.program.programRef).toBe(second.program.programRef);
+    expect(firstModel).not.toBe(secondModel);
+    expect("modelRef" in first.program).toBe(false);
+    expect("providerRef" in first.program).toBe(false);
+  });
+});

--- a/modules/objective/inventory-transfer.ts
+++ b/modules/objective/inventory-transfer.ts
@@ -1,0 +1,540 @@
+import { createHash } from "node:crypto";
+
+import type { EvidenceReservationV1, EvidenceSealV1 } from "../river/contracts.ts";
+import {
+  buildAuthorizedActionEnvelopeV1,
+  SyntheticRiverReservationServiceV1,
+} from "../river/reservation-service.ts";
+import {
+  EffectVerificationServiceV1,
+  type PostExecutionObservationV1,
+  type VerifiedEffectV1,
+} from "../synnergyze/effect-verification.ts";
+import {
+  ControlledExecutionGateV1,
+  type SyntheticCapabilityAdapterInputV1,
+  type SyntheticCapabilityAdapterResultV1,
+  type SyntheticCapabilityAdapterV1,
+} from "../synnergyze/execution-gate.ts";
+import {
+  evaluateSyntheticWardenDecisionV1,
+  type SyntheticWardenDecisionPolicyV1,
+} from "../warden/decision-service.ts";
+import type { WardenDecisionRequestV1, WardenExecutionCheckpointV1 } from "../warden/contracts.ts";
+import type {
+  AcceptanceResultV1,
+  InventoryTransferProofV1,
+  InventoryTransferSpecV1,
+  ObjectiveAuthorityEnvelopeV1,
+  ObjectiveEffectV1,
+  ObjectiveEventV1,
+  ObjectiveProgramBundleV1,
+  ObjectiveProjectionV1,
+  ObjectiveRefV1,
+} from "./contracts.ts";
+
+const TRANSFER_CAPABILITY = "inventory.transfer";
+const TRANSFER_ADAPTER = "SYNTHETIC-INVENTORY-TRANSFER-ADAPTER-001";
+const INVENTORY_OBSERVER = "SYNTHETIC-INVENTORY-OBSERVER-001";
+
+function digest(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function parseInstant(value: string, errorCode: string): number {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) throw new Error(errorCode);
+  return parsed;
+}
+
+function targetRef(spec: InventoryTransferSpecV1): string {
+  return `INVENTORY-TRANSFER:${spec.sourceLocationRef}->${spec.destinationLocationRef}:${spec.skuRef}`;
+}
+
+function resourceRefs(spec: InventoryTransferSpecV1): readonly string[] {
+  return [spec.sourceLocationRef, spec.destinationLocationRef, spec.skuRef];
+}
+
+function assertObjectiveAuthority(
+  objective: ObjectiveRefV1,
+  authority: ObjectiveAuthorityEnvelopeV1,
+  spec: InventoryTransferSpecV1,
+  compiledAt: string,
+): void {
+  if (objective.status !== "AUTHORIZED" && objective.status !== "ACTIVE") {
+    throw new Error("objective_not_authorized");
+  }
+  if (authority.decision !== "ALLOW" || authority.state !== "ACTIVE") {
+    throw new Error("objective_authority_allow_required");
+  }
+  if (authority.objectiveRef !== objective.objectiveRef) throw new Error("objective_authority_mismatch");
+  if (authority.principalRef !== objective.principalRef) throw new Error("objective_principal_mismatch");
+  if (!authority.allowedCapabilityRefs.includes(TRANSFER_CAPABILITY)) {
+    throw new Error("objective_transfer_capability_not_allowed");
+  }
+  for (const resourceRef of resourceRefs(spec)) {
+    if (!authority.resourceRefs.includes(resourceRef)) throw new Error(`objective_resource_not_allowed:${resourceRef}`);
+  }
+  if (spec.quantity <= 0 || !Number.isInteger(spec.quantity)) throw new Error("objective_transfer_quantity_invalid");
+
+  const objectiveFrom = parseInstant(objective.validFrom, "objective_valid_from_invalid");
+  const objectiveUntil = parseInstant(objective.validUntil, "objective_valid_until_invalid");
+  const authorityFrom = parseInstant(authority.validFrom, "objective_authority_valid_from_invalid");
+  const authorityUntil = parseInstant(authority.validUntil, "objective_authority_valid_until_invalid");
+  const compiled = parseInstant(compiledAt, "objective_compile_time_invalid");
+  if (objectiveUntil < objectiveFrom || authorityUntil < authorityFrom) throw new Error("objective_validity_window_invalid");
+  if (compiled < objectiveFrom || compiled > objectiveUntil) throw new Error("objective_outside_validity_window");
+  if (compiled < authorityFrom || compiled > authorityUntil) throw new Error("objective_authority_outside_validity_window");
+}
+
+const EVENT_TYPES: readonly ObjectiveEventV1["eventType"][] = [
+  "RESOLVE_OBJECTIVE",
+  "RESOLVE_RESOURCES",
+  "PREPARE_TRANSFER",
+  "WARDEN_ALLOW",
+  "RESERVE_EVIDENCE",
+  "DISPATCH",
+  "VERIFY_DISPATCH",
+  "RECEIVE",
+  "VERIFY_RECEIPT",
+  "SEAL_EVIDENCE",
+  "RECORD_EFFECTS",
+  "ACCEPTANCE_CHECK",
+  "RECONCILE_PROJECTIONS",
+  "CLOSE_OBJECTIVE",
+];
+
+export function compileInventoryTransferObjective(input: {
+  objective: ObjectiveRefV1;
+  authority: ObjectiveAuthorityEnvelopeV1;
+  transfer: InventoryTransferSpecV1;
+  compiledAt: string;
+}): ObjectiveProgramBundleV1 {
+  const { objective, authority, transfer, compiledAt } = input;
+  assertObjectiveAuthority(objective, authority, transfer, compiledAt);
+
+  const identity = digest(
+    [objective.objectiveRef, objective.version, transfer.sourceLocationRef, transfer.destinationLocationRef, transfer.skuRef, transfer.quantity].join("|"),
+  ).slice(0, 24);
+  const programRef = `OBJECTIVE-PROGRAM:${identity}`;
+  const correlationId = `OBJECTIVE-CORR:${identity}`;
+  const expectedEffectRefs = [
+    `EXPECTED-EFFECT:${objective.objectiveRef}:SOURCE-DECREMENT`,
+    `EXPECTED-EFFECT:${objective.objectiveRef}:DESTINATION-INCREMENT`,
+  ];
+  const requiredEvidenceRefs = authority.evidenceRequirementRefs;
+  const events: ObjectiveEventV1[] = EVENT_TYPES.map((eventType, index) => {
+    const sequence = index + 1;
+    const material = eventType === "PREPARE_TRANSFER" || eventType === "DISPATCH" || eventType === "RECEIVE" || eventType === "RECORD_EFFECTS";
+    return {
+      eventRef: `OBJECTIVE-EVENT:${identity}:${String(sequence).padStart(2, "0")}`,
+      eventType,
+      sequence,
+      objectiveRef: objective.objectiveRef,
+      programRef,
+      authorityRef: authority.authorityRef,
+      correlationId,
+      idempotencyKey: `OBJECTIVE-IDEMPOTENCY:${identity}:${String(sequence).padStart(2, "0")}`,
+      capabilityRef: material ? TRANSFER_CAPABILITY : undefined,
+      targetRef: material ? targetRef(transfer) : undefined,
+      expectedEffectRefs: material ? expectedEffectRefs : [],
+      requiredEvidenceRefs: eventType === "DISPATCH" || eventType === "RECEIVE" || eventType === "SEAL_EVIDENCE" ? requiredEvidenceRefs : [],
+    };
+  });
+
+  return {
+    program: {
+      programRef,
+      objectiveRef: objective.objectiveRef,
+      objectiveVersion: objective.version,
+      purposeLineageRef: `PURPOSE-LINEAGE:${digest(`${objective.principalRef}|${objective.objectiveRef}|${authority.authorityRef}`).slice(0, 24)}`,
+      principalRef: objective.principalRef,
+      actorRef: authority.actorRef,
+      authorityRef: authority.authorityRef,
+      correlationId,
+      eventRefs: events.map((event) => event.eventRef),
+      transfer,
+    },
+    events,
+  };
+}
+
+function inventoryKey(locationRef: string, skuRef: string): string {
+  return `${locationRef}|${skuRef}`;
+}
+
+export class InMemoryInventoryLedgerV1 {
+  private readonly quantities = new Map<string, number>();
+
+  set(locationRef: string, skuRef: string, quantity: number): void {
+    if (!Number.isInteger(quantity) || quantity < 0) throw new Error("inventory_quantity_invalid");
+    this.quantities.set(inventoryKey(locationRef, skuRef), quantity);
+  }
+
+  get(locationRef: string, skuRef: string): number {
+    return this.quantities.get(inventoryKey(locationRef, skuRef)) ?? 0;
+  }
+
+  transfer(spec: InventoryTransferSpecV1): { sourcePrior: number; sourceNew: number; destinationPrior: number; destinationNew: number } {
+    const sourcePrior = this.get(spec.sourceLocationRef, spec.skuRef);
+    const destinationPrior = this.get(spec.destinationLocationRef, spec.skuRef);
+    if (sourcePrior < spec.quantity) throw new Error("inventory_source_insufficient");
+    const sourceNew = sourcePrior - spec.quantity;
+    const destinationNew = destinationPrior + spec.quantity;
+    this.set(spec.sourceLocationRef, spec.skuRef, sourceNew);
+    this.set(spec.destinationLocationRef, spec.skuRef, destinationNew);
+    return { sourcePrior, sourceNew, destinationPrior, destinationNew };
+  }
+}
+
+export class SyntheticInventoryTransferAdapterV1 implements SyntheticCapabilityAdapterV1 {
+  readonly adapterRef = TRANSFER_ADAPTER;
+  readonly capabilityRef = TRANSFER_CAPABILITY;
+  private invocations = 0;
+
+  constructor(
+    private readonly ledger: InMemoryInventoryLedgerV1,
+    private readonly transferSpec: InventoryTransferSpecV1,
+  ) {}
+
+  execute(input: SyntheticCapabilityAdapterInputV1): SyntheticCapabilityAdapterResultV1 {
+    if (input.action.capabilityRef !== this.capabilityRef) throw new Error("inventory_adapter_capability_mismatch");
+    if (input.action.targetRef !== targetRef(this.transferSpec)) throw new Error("inventory_adapter_target_mismatch");
+    const result = this.ledger.transfer(this.transferSpec);
+    this.invocations += 1;
+    return {
+      adapterResultRef: `SYNTHETIC-INVENTORY-TRANSFER:${digest(
+        [input.action.actionRef, result.sourcePrior, result.sourceNew, result.destinationPrior, result.destinationNew].join("|"),
+      ).slice(0, 24)}`,
+    };
+  }
+
+  invocationCount(): number {
+    return this.invocations;
+  }
+}
+
+export function observeInventoryTransfer(input: {
+  receipt: { receiptRef: string; actionRef: string; programRef: string; eventRef: string; targetRef: string; correlationId: string; executedAt: string };
+  ledger: InMemoryInventoryLedgerV1;
+  transfer: InventoryTransferSpecV1;
+  sourcePrior: number;
+  destinationPrior: number;
+  observedAt: string;
+}): PostExecutionObservationV1 {
+  const { receipt, ledger, transfer, sourcePrior, destinationPrior, observedAt } = input;
+  const executed = parseInstant(receipt.executedAt, "inventory_execution_time_invalid");
+  const observed = parseInstant(observedAt, "inventory_observation_time_invalid");
+  if (observed < executed) throw new Error("inventory_observation_before_execution");
+
+  const sourceNew = ledger.get(transfer.sourceLocationRef, transfer.skuRef);
+  const destinationNew = ledger.get(transfer.destinationLocationRef, transfer.skuRef);
+  if (sourceNew !== sourcePrior - transfer.quantity || destinationNew !== destinationPrior + transfer.quantity) {
+    throw new Error("inventory_read_after_write_mismatch");
+  }
+  const observedStateRef = `INVENTORY-TRANSFER-OBSERVED:${digest(
+    [transfer.skuRef, sourcePrior, sourceNew, destinationPrior, destinationNew].join("|"),
+  ).slice(0, 24)}`;
+  const evidenceRef = `INVENTORY-OBSERVATION-EVIDENCE:${digest(`${receipt.receiptRef}|${observedStateRef}|${observedAt}`).slice(0, 24)}`;
+  return {
+    observationRef: `INVENTORY-OBSERVATION:${digest(`${receipt.receiptRef}|${evidenceRef}`).slice(0, 24)}`,
+    executionReceiptRef: receipt.receiptRef,
+    actionRef: receipt.actionRef,
+    programRef: receipt.programRef,
+    eventRef: receipt.eventRef,
+    targetRef: receipt.targetRef,
+    correlationId: receipt.correlationId,
+    observerRef: INVENTORY_OBSERVER,
+    observedStateRef,
+    observedAt,
+    sourceEvidenceRef: evidenceRef,
+    synthetic: true,
+  };
+}
+
+interface StoredSealV1 {
+  fingerprint: string;
+  seal: EvidenceSealV1;
+}
+
+export class SyntheticObjectiveRiverSealServiceV1 {
+  private readonly byReservation = new Map<string, StoredSealV1>();
+
+  seal(input: {
+    reservation: EvidenceReservationV1;
+    effect: VerifiedEffectV1;
+    sealedAt: string;
+  }): EvidenceSealV1 {
+    const { reservation, effect, sealedAt } = input;
+    if (effect.reservationRef !== reservation.reservationRef) throw new Error("objective_seal_reservation_mismatch");
+    if (effect.correlationId !== reservation.correlationId) throw new Error("objective_seal_correlation_mismatch");
+    const verified = parseInstant(effect.verifiedAt, "objective_verified_time_invalid");
+    const sealed = parseInstant(sealedAt, "objective_sealed_time_invalid");
+    if (sealed < verified) throw new Error("objective_seal_before_verification");
+    const fingerprint = digest(
+      [reservation.reservationRef, effect.effectRef, effect.verificationRef, sealedAt].join("|"),
+    );
+    const existing = this.byReservation.get(reservation.reservationRef);
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) throw new Error("objective_seal_idempotency_conflict");
+      return { ...existing.seal };
+    }
+    const seal: EvidenceSealV1 = {
+      sealRef: `OBJECTIVE-RIVER-SEAL:${fingerprint.slice(0, 24)}`,
+      reservationRef: reservation.reservationRef,
+      correlationId: reservation.correlationId,
+      state: "SEALED",
+      traceDigest: digest(
+        [reservation.reservationRef, effect.effectRef, effect.verificationRef, effect.observedStateRef].join("|"),
+      ),
+      sealedAt,
+    };
+    this.byReservation.set(reservation.reservationRef, { fingerprint, seal });
+    return { ...seal };
+  }
+}
+
+export function recordInventoryObjectiveEffects(input: {
+  objective: ObjectiveRefV1;
+  bundle: ObjectiveProgramBundleV1;
+  transfer: InventoryTransferSpecV1;
+  verifiedEffect: VerifiedEffectV1;
+  seal: EvidenceSealV1;
+  observedAt: string;
+}): readonly ObjectiveEffectV1[] {
+  const { objective, bundle, transfer, verifiedEffect, seal, observedAt } = input;
+  if (seal.state !== "SEALED" || seal.correlationId !== verifiedEffect.correlationId) {
+    throw new Error("objective_effect_sealed_evidence_required");
+  }
+  if (verifiedEffect.programRef !== bundle.program.programRef) throw new Error("objective_effect_program_mismatch");
+  const recordEvent = bundle.events.find((event) => event.eventType === "RECORD_EFFECTS");
+  if (!recordEvent) throw new Error("objective_record_effect_event_missing");
+  const base = `${objective.objectiveRef}|${bundle.program.programRef}|${verifiedEffect.effectRef}|${seal.sealRef}`;
+  return [
+    {
+      effectRef: `OBJECTIVE-EFFECT:${digest(`${base}|source`).slice(0, 24)}`,
+      objectiveRef: objective.objectiveRef,
+      programRef: bundle.program.programRef,
+      eventRef: recordEvent.eventRef,
+      subjectRef: `${transfer.sourceLocationRef}:${transfer.skuRef}`,
+      observedDeltaOrStateRef: `DELTA:-${transfer.quantity}`,
+      evidenceRef: seal.sealRef,
+      verifiedEffectRef: verifiedEffect.effectRef,
+      classification: "intended",
+      acceptanceRelevance: "REQUIRED",
+      observedAt,
+    },
+    {
+      effectRef: `OBJECTIVE-EFFECT:${digest(`${base}|destination`).slice(0, 24)}`,
+      objectiveRef: objective.objectiveRef,
+      programRef: bundle.program.programRef,
+      eventRef: recordEvent.eventRef,
+      subjectRef: `${transfer.destinationLocationRef}:${transfer.skuRef}`,
+      observedDeltaOrStateRef: `DELTA:+${transfer.quantity}`,
+      evidenceRef: seal.sealRef,
+      verifiedEffectRef: verifiedEffect.effectRef,
+      classification: "intended",
+      acceptanceRelevance: "REQUIRED",
+      observedAt,
+    },
+  ];
+}
+
+export function objectiveProjection(input: {
+  objective: ObjectiveRefV1;
+  bundle: ObjectiveProgramBundleV1;
+  authority: ObjectiveAuthorityEnvelopeV1;
+  effects: readonly ObjectiveEffectV1[];
+  seal: EvidenceSealV1;
+  sourceQuantity: number;
+  destinationQuantity: number;
+}): ObjectiveProjectionV1 {
+  return {
+    objectiveRef: input.objective.objectiveRef,
+    status: input.objective.status,
+    programRef: input.bundle.program.programRef,
+    authorityRef: input.authority.authorityRef,
+    effectRefs: input.effects.map((effect) => effect.effectRef),
+    evidenceRefs: [input.seal.sealRef],
+    sourceQuantity: input.sourceQuantity,
+    destinationQuantity: input.destinationQuantity,
+  };
+}
+
+export function evaluateInventoryTransferAcceptance(input: {
+  objective: ObjectiveRefV1;
+  transfer: InventoryTransferSpecV1;
+  effects: readonly ObjectiveEffectV1[];
+  seal: EvidenceSealV1;
+  frontProjection: ObjectiveProjectionV1;
+  backProjection: ObjectiveProjectionV1;
+  checkedAt: string;
+}): AcceptanceResultV1 {
+  const reasons: string[] = [];
+  const source = input.effects.find((effect) => effect.subjectRef === `${input.transfer.sourceLocationRef}:${input.transfer.skuRef}`);
+  const destination = input.effects.find((effect) => effect.subjectRef === `${input.transfer.destinationLocationRef}:${input.transfer.skuRef}`);
+  if (!source || source.observedDeltaOrStateRef !== `DELTA:-${input.transfer.quantity}`) reasons.push("SOURCE_EFFECT_MISSING_OR_WRONG");
+  if (!destination || destination.observedDeltaOrStateRef !== `DELTA:+${input.transfer.quantity}`) reasons.push("DESTINATION_EFFECT_MISSING_OR_WRONG");
+  if (input.seal.state !== "SEALED") reasons.push("SEALED_EVIDENCE_REQUIRED");
+  if (input.effects.some((effect) => effect.evidenceRef !== input.seal.sealRef)) reasons.push("EFFECT_EVIDENCE_MISMATCH");
+  if (new Set(input.effects.map((effect) => effect.effectRef)).size !== input.effects.length) reasons.push("DUPLICATE_EFFECT");
+  if (JSON.stringify(input.frontProjection) !== JSON.stringify(input.backProjection)) reasons.push("PROJECTION_DIVERGENCE");
+  if (input.effects.some((effect) => effect.objectiveRef !== input.objective.objectiveRef)) reasons.push("PURPOSE_LINEAGE_MISSING");
+
+  return {
+    objectiveRef: input.objective.objectiveRef,
+    profileRef: input.objective.acceptanceProfileRef,
+    result: reasons.length === 0 ? "PASS" : "FAIL",
+    checkedEffectRefs: input.effects.map((effect) => effect.effectRef),
+    checkedEvidenceRefs: [input.seal.sealRef],
+    checkedAt: input.checkedAt,
+    reasonCodes: reasons.length === 0 ? ["AUTHORIZED_OBSERVED_SEALED_EFFECTS_MATCH_OBJECTIVE"] : reasons,
+  };
+}
+
+export interface SyntheticInventoryTransferTimelineV1 {
+  compiledAt: string;
+  actionRequestedAt: string;
+  decidedAt: string;
+  reservedAt: string;
+  checkpointAt: string;
+  executedAt: string;
+  observedAt: string;
+  verifiedAt: string;
+  sealedAt: string;
+  acceptedAt: string;
+}
+
+export function runSyntheticInventoryTransferProof(input: {
+  objective: ObjectiveRefV1;
+  authority: ObjectiveAuthorityEnvelopeV1;
+  transfer: InventoryTransferSpecV1;
+  sourceInitial: number;
+  destinationInitial: number;
+  timeline: SyntheticInventoryTransferTimelineV1;
+}): InventoryTransferProofV1 {
+  const { objective, authority, transfer, timeline } = input;
+  const bundle = compileInventoryTransferObjective({ objective, authority, transfer, compiledAt: timeline.compiledAt });
+  const dispatchEvent = bundle.events.find((event) => event.eventType === "DISPATCH");
+  if (!dispatchEvent) throw new Error("objective_dispatch_event_missing");
+
+  const ledger = new InMemoryInventoryLedgerV1();
+  ledger.set(transfer.sourceLocationRef, transfer.skuRef, input.sourceInitial);
+  ledger.set(transfer.destinationLocationRef, transfer.skuRef, input.destinationInitial);
+
+  const request: WardenDecisionRequestV1 = {
+    requestRef: `WARDEN-REQUEST:${digest(`${objective.objectiveRef}|${dispatchEvent.eventRef}`).slice(0, 24)}`,
+    actorRef: authority.actorRef,
+    representedPrincipalRef: authority.principalRef,
+    actingCapacityRef: authority.actingCapacityRef,
+    contextRef: authority.contextRef,
+    programRef: bundle.program.programRef,
+    eventRef: dispatchEvent.eventRef,
+    action: TRANSFER_CAPABILITY,
+    capabilityRef: TRANSFER_CAPABILITY,
+    targetRef: targetRef(transfer),
+    requestedEffect: objective.desiredStateRef,
+    authorityRefs: [authority.authorityRef, authority.wardenDecisionRef],
+    policyRefs: objective.authorityRequirementRefs,
+    representationSourceRefs: [`REGISTRY:OBJECTIVE:${objective.objectiveRef}`, `REGISTRY:AUTHORITY:${authority.authorityRef}`],
+    requestedAt: timeline.actionRequestedAt,
+    correlationId: bundle.program.correlationId,
+  };
+  const policy: SyntheticWardenDecisionPolicyV1 = {
+    policySnapshotRef: `WARDEN-POLICY-SNAPSHOT:${objective.objectiveRef}`,
+    wardenRef: authority.wardenRef,
+    lifecycle: "ACTIVE",
+    validFrom: authority.validFrom,
+    validUntil: authority.validUntil,
+    actorRef: authority.actorRef,
+    representedPrincipalRef: authority.principalRef,
+    actingCapacityRef: authority.actingCapacityRef,
+    contextRef: authority.contextRef,
+    programRef: bundle.program.programRef,
+    requiredAuthorityRefs: [authority.authorityRef, authority.wardenDecisionRef],
+    requiredPolicyRefs: objective.authorityRequirementRefs,
+    allowedCapabilityRefs: authority.allowedCapabilityRefs,
+    manualReviewCapabilityRefs: [],
+    constraints: authority.constraintRefs,
+  };
+  const decision = evaluateSyntheticWardenDecisionV1({ request, policy, decidedAt: timeline.decidedAt });
+  if (decision.decision !== "ALLOW") throw new Error(`objective_action_not_allowed:${decision.decision}`);
+  const action = buildAuthorizedActionEnvelopeV1(request, decision);
+  const river = new SyntheticRiverReservationServiceV1();
+  const reservation = river.reserve({ request, decision, action, reservedAt: timeline.reservedAt });
+  const checkpoint: WardenExecutionCheckpointV1 = {
+    checkpointRef: `WARDEN-EXEC-CHECK:${decision.decisionRef}`,
+    decisionRef: decision.decisionRef,
+    wardenRef: decision.wardenRef,
+    correlationId: decision.correlationId,
+    state: "VALID",
+    checkedAt: timeline.checkpointAt,
+    reasonCodes: ["objective_authority_active_for_execution"],
+  };
+
+  const adapter = new SyntheticInventoryTransferAdapterV1(ledger, transfer);
+  const gate = new ControlledExecutionGateV1([adapter]);
+  const receipt = gate.execute({ action, reservation, decision, checkpoint, executedAt: timeline.executedAt });
+  const observation = observeInventoryTransfer({
+    receipt,
+    ledger,
+    transfer,
+    sourcePrior: input.sourceInitial,
+    destinationPrior: input.destinationInitial,
+    observedAt: timeline.observedAt,
+  });
+  const verification = new EffectVerificationServiceV1().verify({
+    receipt,
+    observation,
+    verifiedAt: timeline.verifiedAt,
+  });
+  if (verification.state !== "VERIFIED_EFFECT") throw new Error(`objective_effect_verification_failed:${verification.reasonCode}`);
+
+  const seal = new SyntheticObjectiveRiverSealServiceV1().seal({
+    reservation,
+    effect: verification.effect,
+    sealedAt: timeline.sealedAt,
+  });
+  const effects = recordInventoryObjectiveEffects({
+    objective,
+    bundle,
+    transfer,
+    verifiedEffect: verification.effect,
+    seal,
+    observedAt: timeline.observedAt,
+  });
+  const acceptancePending = { ...objective, status: "ACCEPTANCE_PENDING" as const };
+  const frontProjection = objectiveProjection({
+    objective: acceptancePending,
+    bundle,
+    authority,
+    effects,
+    seal,
+    sourceQuantity: ledger.get(transfer.sourceLocationRef, transfer.skuRef),
+    destinationQuantity: ledger.get(transfer.destinationLocationRef, transfer.skuRef),
+  });
+  const backProjection = { ...frontProjection, effectRefs: [...frontProjection.effectRefs], evidenceRefs: [...frontProjection.evidenceRefs] };
+  const acceptance = evaluateInventoryTransferAcceptance({
+    objective: acceptancePending,
+    transfer,
+    effects,
+    seal,
+    frontProjection,
+    backProjection,
+    checkedAt: timeline.acceptedAt,
+  });
+  if (acceptance.result !== "PASS") throw new Error(`objective_acceptance_failed:${acceptance.reasonCodes.join(",")}`);
+
+  return {
+    objective,
+    authority,
+    bundle,
+    verifiedEffectRef: verification.effect.effectRef,
+    riverSealRef: seal.sealRef,
+    effects,
+    frontProjection,
+    backProjection,
+    acceptance,
+    closedObjective: { ...objective, status: "CLOSED" },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:river-reservation": "vitest run modules/river/reservation-service.test.ts",
     "test:controlled-execution": "vitest run modules/synnergyze/execution-gate.test.ts",
     "test:effect-verification": "vitest run modules/synnergyze/effect-verification.test.ts",
+    "test:objective": "vitest run modules/objective/inventory-transfer.test.ts",
     "test:sites": "vitest run api/sites.test.ts",
     "test:site-handoff": "vitest run site-handoff/runtime.test.ts",
     "probe:apple-mpp": "bash scripts/bootstrap-apple-mpp-runner.sh",


### PR DESCRIPTION
## Objective

Implements ESO-73 / `Believers-common-group/SynergyzeGovernance#40` on the accepted Alpha runtime chain without creating a second orchestration or authority model.

Purpose lineage:

`PRINCIPAL → OBJECTIVE → AUTHORITY → PROGRAM → EVENT → EXECUTION → EVIDENCE → EFFECT → ACCEPTANCE`

## Added

- `modules/objective/contracts.ts`
  - provider-neutral Objective, Objective Authority Envelope, Program/Event purpose-lineage, Effect, projection and Acceptance contracts.
- `modules/objective/inventory-transfer.ts`
  - deterministic Objective → 14-event Program compiler;
  - explicit Objective authority/resource/evidence scope validation;
  - in-memory synthetic inventory ledger;
  - `inventory.transfer` capability adapter used through the existing `ControlledExecutionGateV1`;
  - existing Warden action decision + River reservation + fresh execution checkpoint reuse;
  - post-execution read-after-write observation;
  - existing effect-verification service reuse;
  - bounded synthetic River seal only after verified observation;
  - source `-10` / destination `+10` Objective Effects only after sealed evidence;
  - deterministic Front/Back projection and acceptance evaluation;
  - Objective closes only after PASS.
- `modules/objective/inventory-transfer.test.ts`
  - complete 14-event purpose lineage;
  - authorized synthetic transfer exactly once;
  - denied/revoked/expired/out-of-scope Objective authority fails closed;
  - read-after-write mismatch cannot become Effect;
  - projection divergence fails acceptance;
  - duplicate Effects/evidence mismatch fail acceptance;
  - model/provider identity remains outside Objective ownership/authority lineage.
- `.vsr/repository-components.yaml`
  - registers `CMP-SYNNERGYZE-OBJECTIVE-INVENTORY-001` as conformance-only, activation false.
- `package.json`
  - adds `test:objective`.

## Canonical boundaries

This reuses the integrated sequence:

`Warden decision → River reservation → controlled execution → EXECUTED_UNVERIFIED → observation → VERIFIED_EFFECT`

and extends it only to:

`VERIFIED_EFFECT → synthetic River seal → Objective Effect records → acceptance`.

## Hard prohibitions

This PR does **not**:
- activate a production Warden;
- use Supabase/Neon/Vercel/Cloudflare as semantic authority;
- invoke a real ERP/inventory provider;
- write to a real VOI/Scotts location;
- create financial/legal/economic obligations;
- imply SILK settlement or finality;
- activate a real Alpha/VOI canary;
- give VSR/Empire UI authority.

Promotion requires fresh test/lint/type-check/bridge CI on the exact head. Synthetic PASS is conformance evidence only.