### PR TITLE
BAG-LOCK-001 — bind current Warden→River→execution runtime to device security state

### DIFF
--- a/.vsr/repository-components.yaml
+++ b/.vsr/repository-components.yaml
@@ -6,6 +6,8 @@ canonical_governance:
   repository: Believers-common-group/SynergyzeGovernance
   refs:
     - issue:13
+    - issue:19
+    - issue:20
     - issue:34
     - issue:35
     - issue:36
@@ -75,10 +77,12 @@ components:
       - actor-is-not-represented-principal
       - represented-principal-is-not-acting-capacity
       - acting-capacity-is-not-authority
+      - device-security-state-is-not-warden-authority
     input_contracts:
       - SynnergyzeProgramDraftV1
       - SynnergyzeEventDraftV1
       - ResolvedRepresentationContextV1
+      - ResolvedDeviceSecurityContextV1
       - WardenRequestBridgeInputV1
     output_contracts:
       - WardenDecisionRequestV1
@@ -86,7 +90,9 @@ components:
     depends_on:
       - CMP-SYNNERGYZE-PROGRAM-EVENT-001
       - REGISTRY-REPRESENTATION-RESOLUTION
+      - REGISTRY-DEVICE-SECURITY-RESOLUTION
       - WARDEN-RUNTIME-001-CONTRACT
+      - BAG-LOCK-001
     downstream_boundaries:
       - WARDEN-RUNTIME-001
     required_request_fields:
@@ -101,9 +107,17 @@ components:
       - targetRef
       - representationSourceRefs
       - correlationId
+    conditional_device_guards:
+      - device-bound-event-requires-security-resolution
+      - exact-device-reference-match
+      - device-state-active-before-warden-request
+      - security-resolution-and-evidence-required
+      - security-resolution-not-future-or-expired
+      - security-evidence-bound-into-request-identity
     forbidden:
       - infer-represented-principal-from-actor
       - infer-acting-capacity-from-ui-or-provider-state
+      - authorize-device-bound-event-with-unresolved-or-non-active-device-security
       - evaluate-warden-policy
       - issue-action-token
       - reserve-or-seal-river-evidence
@@ -131,6 +145,7 @@ components:
       - EvidenceReservationV1
       - WardenDecisionV1
       - WardenExecutionCheckpointV1
+      - ResolvedDeviceSecurityContextV1
       - ControlledExecutionRequestV1
     output_contracts:
       - SynnergyzeExecutionReceiptV1
@@ -140,6 +155,7 @@ components:
       - WARDEN-RUNTIME-001
       - RIVEROS-001
       - CMP-SYNNERGYZE-WARDEN-REQUEST-001
+      - BAG-LOCK-001
     adapter_allowlist:
       - SYNTHETIC-SERVICE-REQUEST-ADAPTER-001
     required_guards:
@@ -148,12 +164,19 @@ components:
       - fresh-warden-execution-checkpoint
       - reservation-action-decision-correlation-match
       - reservation-authorization-digest-match
+      - request-time-device-security-binding-if-device-bound
+      - fresh-device-security-recheck-if-device-bound
+      - device-security-device-and-policy-match
+      - device-security-active-and-evidenced-at-execution
+      - device-security-time-validity-at-execution
       - capability-adapter-registration
       - idempotent-execution-replay
     forbidden:
       - execute-non-allow-decision
       - execute-revoked-expired-or-superseded-checkpoint
       - execute-without-river-reservation
+      - execute-device-bound-action-with-missing-stale-mismatched-or-non-active-device-security
+      - claim-hardware-port-or-radio-enforcement
       - execute-unregistered-capability
       - create-effect-receipt
       - mark-effect-verified
@@ -164,6 +187,7 @@ components:
       - invoke-real-external-provider
     tests:
       - modules/synnergyze/execution-gate.test.ts
+      - modules/synnergyze/warden-request-bridge.test.ts
       - modules/river/reservation-service.test.ts
       - modules/warden/decision-service.test.ts
     activation_gate: explicit-controlled-connector-integration-and-authorization

--- a/modules/river/contracts.ts
+++ b/modules/river/contracts.ts
@@ -10,6 +10,9 @@ export interface ActionEnvelopeV1 {
   action: string;
   capabilityRef: string;
   targetRef: string;
+  executionDeviceRef?: string;
+  deviceSecurityPolicyRef?: string;
+  deviceSecurityRequestDigest?: string;
   wardenDecisionRef: string;
   actionToken: string;
   requestedAt: string;

--- a/modules/river/reservation-service.ts
+++ b/modules/river/reservation-service.ts
@@ -31,6 +31,30 @@ function actionAuthorizationDigest(actionToken: string): string {
   return `sha256:${digest(actionToken)}`;
 }
 
+function stableUnique(values: readonly string[]): readonly string[] {
+  return [...new Set(values)].sort();
+}
+
+function requestDeviceSecurityDigest(request: WardenDecisionRequestV1): string | undefined {
+  if (!request.executionDeviceRef) return undefined;
+  if (request.deviceSecurityState !== "ACTIVE") {
+    throw new Error("river_device_security_active_request_required");
+  }
+  if (!request.deviceSecuritySourceRefs?.length || !request.deviceSecurityResolvedAt) {
+    throw new Error("river_device_security_request_evidence_required");
+  }
+  return `sha256:${digest(
+    JSON.stringify({
+      deviceRef: request.executionDeviceRef,
+      state: request.deviceSecurityState,
+      policyRef: request.deviceSecurityPolicyRef ?? null,
+      sourceRefs: stableUnique(request.deviceSecuritySourceRefs),
+      resolvedAt: request.deviceSecurityResolvedAt,
+      validUntil: request.deviceSecurityValidUntil ?? null,
+    }),
+  )}`;
+}
+
 function canonicalActionPayload(request: WardenDecisionRequestV1, decision: WardenDecisionV1) {
   if (decision.decision !== "ALLOW") {
     throw new Error("river_warden_allow_required");
@@ -62,6 +86,9 @@ function canonicalActionPayload(request: WardenDecisionRequestV1, decision: Ward
     action: request.action,
     capabilityRef: request.capabilityRef,
     targetRef: request.targetRef,
+    executionDeviceRef: request.executionDeviceRef,
+    deviceSecurityPolicyRef: request.deviceSecurityPolicyRef,
+    deviceSecurityRequestDigest: requestDeviceSecurityDigest(request),
     wardenDecisionRef: decision.decisionRef,
     actionToken: decision.actionToken,
     requestedAt: request.requestedAt,
@@ -107,6 +134,9 @@ function assertExactAction(expected: ActionEnvelopeV1, actual: ActionEnvelopeV1)
     "action",
     "capabilityRef",
     "targetRef",
+    "executionDeviceRef",
+    "deviceSecurityPolicyRef",
+    "deviceSecurityRequestDigest",
     "wardenDecisionRef",
     "actionToken",
     "requestedAt",

--- a/modules/synnergyze/contracts.ts
+++ b/modules/synnergyze/contracts.ts
@@ -4,6 +4,29 @@ export type SynnergyzePlanningStateV1 =
   | "BLOCKED_REQUIREMENT"
   | "READY_FOR_AUTHORIZATION";
 
+export type DeviceSecurityStateV1 =
+  | "ACTIVE"
+  | "BAG_LOCK_REQUESTED"
+  | "SEALED"
+  | "SEALED_ALERT"
+  | "UNSEAL_PENDING"
+  | "WARDEN_REAUTH"
+  | "CONTROLLED_RECONNECT"
+  | "RECOVERY_REQUIRED";
+
+export type DeviceSecurityAssuranceLevelV1 = "L0" | "L1" | "L2" | "L3" | "L4";
+
+export interface ResolvedDeviceSecurityContextV1 {
+  resolutionRef: string;
+  deviceRef: string;
+  state: DeviceSecurityStateV1;
+  policyRef?: string;
+  evidenceRef: string;
+  assuranceLevel?: DeviceSecurityAssuranceLevelV1;
+  resolvedAt: string;
+  validUntil?: string;
+}
+
 export interface SynnergyzeEventDraftV1 {
   eventRef: string;
   programRef: string;
@@ -15,6 +38,7 @@ export interface SynnergyzeEventDraftV1 {
   contextRef: string;
   placeRef?: string;
   targetRef?: string;
+  executionDeviceRef?: string;
   action: string;
   capabilityRef?: string;
   requestedEffect?: string;
@@ -90,6 +114,11 @@ export interface SynnergyzeExecutionReceiptV1 {
   correlationId: string;
   adapterRef: string;
   adapterResultRef: string;
+  executionDeviceRef?: string;
+  deviceSecurityResolutionRef?: string;
+  deviceSecurityEvidenceRef?: string;
+  deviceSecurityPolicyRef?: string;
+  deviceSecurityAssuranceLevel?: DeviceSecurityAssuranceLevelV1;
   state: "EXECUTED_UNVERIFIED";
   executedAt: string;
   synthetic: true;

--- a/modules/synnergyze/execution-gate.test.ts
+++ b/modules/synnergyze/execution-gate.test.ts
@@ -9,6 +9,10 @@ import {
   evaluateSyntheticWardenDecisionV1,
   type SyntheticWardenDecisionPolicyV1,
 } from "../warden/decision-service.ts";
+import type {
+  DeviceSecurityStateV1,
+  ResolvedDeviceSecurityContextV1,
+} from "./contracts.ts";
 import {
   ControlledExecutionGateV1,
   SyntheticServiceRequestCreateAdapterV1,
@@ -37,6 +41,39 @@ function request(overrides: Partial<WardenDecisionRequestV1> = {}): WardenDecisi
     representationSourceRefs: ["REGISTRY:REPRESENTATION-001"],
     requestedAt: "2026-08-14T09:00:00.000Z",
     correlationId: "CORR-EXEC-001",
+    ...overrides,
+  };
+}
+
+function deviceBoundRequest(
+  overrides: Partial<WardenDecisionRequestV1> = {},
+): WardenDecisionRequestV1 {
+  return request({
+    executionDeviceRef: "ALPHA-DEVICE-001",
+    deviceSecurityState: "ACTIVE",
+    deviceSecurityPolicyRef: "BAG-LOCK-POLICY:ALPHA-001",
+    deviceSecuritySourceRefs: [
+      "REGISTRY-DEVICE-SECURITY:ALPHA-DEVICE-001:REQUEST",
+      "RIVER-EVIDENCE:BAG-LOCK-REQUEST-001",
+    ],
+    deviceSecurityResolvedAt: "2026-08-14T08:59:58.000Z",
+    deviceSecurityValidUntil: "2026-08-14T09:04:59.000Z",
+    ...overrides,
+  });
+}
+
+function executionDeviceSecurity(
+  overrides: Partial<ResolvedDeviceSecurityContextV1> = {},
+): ResolvedDeviceSecurityContextV1 {
+  return {
+    resolutionRef: "REGISTRY-DEVICE-SECURITY:ALPHA-DEVICE-001:EXECUTION",
+    deviceRef: "ALPHA-DEVICE-001",
+    state: "ACTIVE",
+    policyRef: "BAG-LOCK-POLICY:ALPHA-001",
+    evidenceRef: "RIVER-EVIDENCE:BAG-LOCK-EXECUTION-001",
+    assuranceLevel: "L1",
+    resolvedAt: "2026-08-14T09:00:26.000Z",
+    validUntil: "2026-08-14T09:01:00.000Z",
     ...overrides,
   };
 }
@@ -92,6 +129,13 @@ function chain(input?: {
   return { request: requestValue, decision, action, reservation, checkpoint };
 }
 
+function deviceChain() {
+  return {
+    ...chain({ request: deviceBoundRequest() }),
+    executionDeviceSecurity: executionDeviceSecurity(),
+  };
+}
+
 function gate() {
   const adapter = new SyntheticServiceRequestCreateAdapterV1();
   return { adapter, gate: new ControlledExecutionGateV1([adapter]) };
@@ -108,6 +152,7 @@ describe("VSR-NETWORK-CONTROLLED-EXECUTION-GATE-001", () => {
     expect(receipt.idempotentReplay).toBe(false);
     expect(receipt.adapterRef).toBe(runtime.adapter.adapterRef);
     expect(receipt.adapterResultRef).toMatch(/^SYNTHETIC-SERVICE-REQUEST:/);
+    expect(receipt.executionDeviceRef).toBeUndefined();
     expect("effectRef" in receipt).toBe(false);
     expect("verifiedAt" in receipt).toBe(false);
     expect(runtime.adapter.invocationCount()).toBe(1);
@@ -246,5 +291,141 @@ describe("VSR-NETWORK-CONTROLLED-EXECUTION-GATE-001", () => {
       }),
     ).toThrow("execution_idempotency_conflict");
     expect(runtime.adapter.invocationCount()).toBe(1);
+  });
+
+  it("executes a device-bound action only with a fresh matching ACTIVE security resolution", () => {
+    const c = deviceChain();
+    const runtime = gate();
+    const receipt = runtime.gate.execute({ ...c, executedAt: EXECUTED_AT });
+
+    expect(receipt.state).toBe("EXECUTED_UNVERIFIED");
+    expect(receipt.executionDeviceRef).toBe("ALPHA-DEVICE-001");
+    expect(receipt.deviceSecurityResolutionRef).toBe(c.executionDeviceSecurity.resolutionRef);
+    expect(receipt.deviceSecurityEvidenceRef).toBe(c.executionDeviceSecurity.evidenceRef);
+    expect(receipt.deviceSecurityPolicyRef).toBe("BAG-LOCK-POLICY:ALPHA-001");
+    expect(runtime.adapter.invocationCount()).toBe(1);
+  });
+
+  it("blocks a device-bound action when fresh execution security is missing", () => {
+    const c = deviceChain();
+    const runtime = gate();
+    const { executionDeviceSecurity: _ignored, ...withoutSecurity } = c;
+
+    expect(() => runtime.gate.execute({ ...withoutSecurity, executedAt: EXECUTED_AT })).toThrow(
+      "execution_device_security_required",
+    );
+    expect(runtime.adapter.invocationCount()).toBe(0);
+  });
+
+  it("blocks a device security checkpoint for another device", () => {
+    const c = deviceChain();
+    const runtime = gate();
+
+    expect(() =>
+      runtime.gate.execute({
+        ...c,
+        executionDeviceSecurity: executionDeviceSecurity({ deviceRef: "ALPHA-DEVICE-OTHER" }),
+        executedAt: EXECUTED_AT,
+      }),
+    ).toThrow("execution_device_security_context_mismatch");
+    expect(runtime.adapter.invocationCount()).toBe(0);
+  });
+
+  for (const state of [
+    "BAG_LOCK_REQUESTED",
+    "SEALED",
+    "SEALED_ALERT",
+    "UNSEAL_PENDING",
+    "WARDEN_REAUTH",
+    "CONTROLLED_RECONNECT",
+    "RECOVERY_REQUIRED",
+  ] as const satisfies readonly DeviceSecurityStateV1[]) {
+    it(`blocks device-bound execution if state changes to ${state} after authorization`, () => {
+      const c = deviceChain();
+      const runtime = gate();
+
+      expect(() =>
+        runtime.gate.execute({
+          ...c,
+          executionDeviceSecurity: executionDeviceSecurity({ state }),
+          executedAt: EXECUTED_AT,
+        }),
+      ).toThrow(`execution_device_security_state_${state.toLowerCase()}`);
+      expect(runtime.adapter.invocationCount()).toBe(0);
+    });
+  }
+
+  it("blocks missing evidence, policy drift, future resolution and expired security at execution", () => {
+    const c = deviceChain();
+    const cases: Array<[ResolvedDeviceSecurityContextV1, string]> = [
+      [executionDeviceSecurity({ evidenceRef: "" }), "execution_device_security_evidence_required"],
+      [
+        executionDeviceSecurity({ policyRef: "BAG-LOCK-POLICY:OTHER" }),
+        "execution_device_security_policy_mismatch",
+      ],
+      [
+        executionDeviceSecurity({ resolvedAt: "2026-08-14T09:00:31.000Z" }),
+        "execution_device_security_from_future",
+      ],
+      [
+        executionDeviceSecurity({ validUntil: "2026-08-14T09:00:29.000Z" }),
+        "execution_device_security_expired",
+      ],
+    ];
+
+    for (const [executionDeviceSecurityValue, expected] of cases) {
+      const runtime = gate();
+      expect(() =>
+        runtime.gate.execute({
+          ...c,
+          executionDeviceSecurity: executionDeviceSecurityValue,
+          executedAt: EXECUTED_AT,
+        }),
+      ).toThrow(expected);
+      expect(runtime.adapter.invocationCount()).toBe(0);
+    }
+  });
+
+  it("replays identical device-bound execution idempotently", () => {
+    const c = deviceChain();
+    const runtime = gate();
+    const first = runtime.gate.execute({ ...c, executedAt: EXECUTED_AT });
+    const second = runtime.gate.execute({ ...c, executedAt: EXECUTED_AT });
+
+    expect(second.receiptRef).toBe(first.receiptRef);
+    expect(second.idempotentReplay).toBe(true);
+    expect(runtime.adapter.invocationCount()).toBe(1);
+  });
+
+  it("fails closed when the same authorized action is replayed with different security evidence", () => {
+    const c = deviceChain();
+    const runtime = gate();
+    runtime.gate.execute({ ...c, executedAt: EXECUTED_AT });
+
+    expect(() =>
+      runtime.gate.execute({
+        ...c,
+        executionDeviceSecurity: executionDeviceSecurity({
+          resolutionRef: "REGISTRY-DEVICE-SECURITY:ALPHA-DEVICE-001:EXECUTION:2",
+          evidenceRef: "RIVER-EVIDENCE:BAG-LOCK-EXECUTION-002",
+        }),
+        executedAt: EXECUTED_AT,
+      }),
+    ).toThrow("execution_idempotency_conflict");
+    expect(runtime.adapter.invocationCount()).toBe(1);
+  });
+
+  it("rejects stray device security on a non-device-bound action", () => {
+    const c = chain();
+    const runtime = gate();
+
+    expect(() =>
+      runtime.gate.execute({
+        ...c,
+        executionDeviceSecurity: executionDeviceSecurity(),
+        executedAt: EXECUTED_AT,
+      }),
+    ).toThrow("execution_device_security_unexpected");
+    expect(runtime.adapter.invocationCount()).toBe(0);
   });
 });

--- a/modules/synnergyze/execution-gate.ts
+++ b/modules/synnergyze/execution-gate.ts
@@ -5,13 +5,17 @@ import type {
   WardenDecisionV1,
   WardenExecutionCheckpointV1,
 } from "../warden/contracts.ts";
-import type { SynnergyzeExecutionReceiptV1 } from "./contracts.ts";
+import type {
+  ResolvedDeviceSecurityContextV1,
+  SynnergyzeExecutionReceiptV1,
+} from "./contracts.ts";
 
 export interface ControlledExecutionRequestV1 {
   action: ActionEnvelopeV1;
   reservation: EvidenceReservationV1;
   decision: WardenDecisionV1;
   checkpoint: WardenExecutionCheckpointV1;
+  executionDeviceSecurity?: ResolvedDeviceSecurityContextV1;
   executedAt: string;
 }
 
@@ -112,6 +116,45 @@ function assertCheckpoint(
   if (checked > executed) throw new Error("execution_checkpoint_from_future");
 }
 
+function assertDeviceSecurity(
+  action: ActionEnvelopeV1,
+  security: ResolvedDeviceSecurityContextV1 | undefined,
+  executedAt: string,
+): void {
+  if (!action.executionDeviceRef) {
+    if (security) throw new Error("execution_device_security_unexpected");
+    return;
+  }
+
+  if (!action.deviceSecurityRequestDigest) {
+    throw new Error("execution_device_security_request_binding_required");
+  }
+  if (!security) throw new Error("execution_device_security_required");
+  if (security.deviceRef !== action.executionDeviceRef) {
+    throw new Error("execution_device_security_context_mismatch");
+  }
+  if (security.state !== "ACTIVE") {
+    throw new Error(`execution_device_security_state_${security.state.toLowerCase()}`);
+  }
+  if (!security.resolutionRef || !security.evidenceRef) {
+    throw new Error("execution_device_security_evidence_required");
+  }
+  if (action.deviceSecurityPolicyRef && security.policyRef !== action.deviceSecurityPolicyRef) {
+    throw new Error("execution_device_security_policy_mismatch");
+  }
+
+  const resolved = parseInstant(security.resolvedAt, "execution_invalid_device_security_time");
+  const executed = parseInstant(executedAt, "execution_invalid_execution_time");
+  if (resolved > executed) throw new Error("execution_device_security_from_future");
+  if (security.validUntil) {
+    const validUntil = parseInstant(
+      security.validUntil,
+      "execution_invalid_device_security_validity",
+    );
+    if (executed > validUntil) throw new Error("execution_device_security_expired");
+  }
+}
+
 function executionFingerprint(
   input: ControlledExecutionRequestV1,
   adapterRef: string,
@@ -126,6 +169,20 @@ function executionFingerprint(
       capabilityRef: input.action.capabilityRef,
       targetRef: input.action.targetRef,
       correlationId: input.action.correlationId,
+      executionDeviceRef: input.action.executionDeviceRef ?? null,
+      deviceSecurityRequestDigest: input.action.deviceSecurityRequestDigest ?? null,
+      executionDeviceSecurity: input.executionDeviceSecurity
+        ? {
+            resolutionRef: input.executionDeviceSecurity.resolutionRef,
+            deviceRef: input.executionDeviceSecurity.deviceRef,
+            state: input.executionDeviceSecurity.state,
+            policyRef: input.executionDeviceSecurity.policyRef ?? null,
+            evidenceRef: input.executionDeviceSecurity.evidenceRef,
+            assuranceLevel: input.executionDeviceSecurity.assuranceLevel ?? null,
+            resolvedAt: input.executionDeviceSecurity.resolvedAt,
+            validUntil: input.executionDeviceSecurity.validUntil ?? null,
+          }
+        : null,
       adapterRef,
       executedAt: input.executedAt,
     }),
@@ -177,6 +234,7 @@ export class ControlledExecutionGateV1 {
       input.checkpoint,
       input.executedAt,
     );
+    assertDeviceSecurity(input.action, input.executionDeviceSecurity, input.executedAt);
 
     const adapter = this.adapters.get(input.action.capabilityRef);
     if (!adapter) throw new Error(`execution_capability_not_registered:${input.action.capabilityRef}`);
@@ -204,6 +262,8 @@ export class ControlledExecutionGateV1 {
         input.reservation.reservationRef,
         input.decision.decisionRef,
         input.checkpoint.checkpointRef,
+        input.executionDeviceSecurity?.resolutionRef ?? "NO-DEVICE-SECURITY",
+        input.executionDeviceSecurity?.evidenceRef ?? "NO-DEVICE-EVIDENCE",
         adapter.adapterRef,
         adapterResult.adapterResultRef,
       ].join("|"),
@@ -221,6 +281,11 @@ export class ControlledExecutionGateV1 {
       correlationId: input.action.correlationId,
       adapterRef: adapter.adapterRef,
       adapterResultRef: adapterResult.adapterResultRef,
+      executionDeviceRef: input.action.executionDeviceRef,
+      deviceSecurityResolutionRef: input.executionDeviceSecurity?.resolutionRef,
+      deviceSecurityEvidenceRef: input.executionDeviceSecurity?.evidenceRef,
+      deviceSecurityPolicyRef: input.executionDeviceSecurity?.policyRef,
+      deviceSecurityAssuranceLevel: input.executionDeviceSecurity?.assuranceLevel,
       state: "EXECUTED_UNVERIFIED",
       executedAt: input.executedAt,
       synthetic: true,

--- a/modules/synnergyze/warden-request-bridge.test.ts
+++ b/modules/synnergyze/warden-request-bridge.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import { normalizeQelExpressionV1 } from "../qel/normalizer.ts";
 import { compileQelPlanToSynnergyzeDraftsV1 } from "./program-bridge.ts";
+import type {
+  DeviceSecurityStateV1,
+  ResolvedDeviceSecurityContextV1,
+} from "./contracts.ts";
 import {
   buildWardenDecisionRequestV1,
   type ResolvedRepresentationContextV1,
@@ -57,6 +61,30 @@ function representation(
   };
 }
 
+function deviceSecurity(
+  overrides: Partial<ResolvedDeviceSecurityContextV1> = {},
+): ResolvedDeviceSecurityContextV1 {
+  return {
+    resolutionRef: "REGISTRY-DEVICE-SECURITY:ALPHA-DEVICE-001:ACTIVE",
+    deviceRef: "ALPHA-DEVICE-001",
+    state: "ACTIVE",
+    policyRef: "BAG-LOCK-POLICY:ALPHA-001",
+    evidenceRef: "RIVER-EVIDENCE:BAG-LOCK-ACTIVE-001",
+    assuranceLevel: "L1",
+    resolvedAt: "2026-08-14T06:02:30Z",
+    validUntil: "2026-08-14T06:10:00Z",
+    ...overrides,
+  };
+}
+
+function deviceBoundEvent() {
+  const bundle = readyPlanningBundle();
+  return {
+    bundle,
+    event: { ...bundle.events[0], executionDeviceRef: "ALPHA-DEVICE-001" },
+  };
+}
+
 describe("VSR-NETWORK-WARDEN-REQUEST-BRIDGE-001", () => {
   it("builds one explicit non-decision Warden request from a ready Event", () => {
     const bundle = readyPlanningBundle();
@@ -76,6 +104,7 @@ describe("VSR-NETWORK-WARDEN-REQUEST-BRIDGE-001", () => {
     expect(result.request.capabilityRef).toBe("service_request.create");
     expect(result.request.programRef).toBe(bundle.program.programRef);
     expect(result.request.eventRef).toBe(bundle.events[0].eventRef);
+    expect(result.request.executionDeviceRef).toBeUndefined();
     expect("decision" in result.request).toBe(false);
     expect("actionToken" in result.request).toBe(false);
   });
@@ -180,5 +209,133 @@ describe("VSR-NETWORK-WARDEN-REQUEST-BRIDGE-001", () => {
     });
 
     expect(result).toMatchObject({ ok: false, code: "EVENT_NOT_IN_PROGRAM" });
+  });
+
+  it("requires a resolved security context for a device-bound Event", () => {
+    const { bundle, event } = deviceBoundEvent();
+    const result = buildWardenDecisionRequestV1({
+      program: bundle.program,
+      event,
+      representation: representation(),
+      requestedAt: "2026-08-14T06:03:00Z",
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "DEVICE_SECURITY_REQUIRED" });
+  });
+
+  it("rejects a security context for another device", () => {
+    const { bundle, event } = deviceBoundEvent();
+    const result = buildWardenDecisionRequestV1({
+      program: bundle.program,
+      event,
+      representation: representation(),
+      deviceSecurity: deviceSecurity({ deviceRef: "ALPHA-DEVICE-OTHER" }),
+      requestedAt: "2026-08-14T06:03:00Z",
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "DEVICE_SECURITY_CONTEXT_MISMATCH" });
+  });
+
+  for (const state of [
+    "BAG_LOCK_REQUESTED",
+    "SEALED",
+    "SEALED_ALERT",
+    "UNSEAL_PENDING",
+    "WARDEN_REAUTH",
+    "CONTROLLED_RECONNECT",
+    "RECOVERY_REQUIRED",
+  ] as const satisfies readonly DeviceSecurityStateV1[]) {
+    it(`blocks Warden request while device security state is ${state}`, () => {
+      const { bundle, event } = deviceBoundEvent();
+      const result = buildWardenDecisionRequestV1({
+        program: bundle.program,
+        event,
+        representation: representation(),
+        deviceSecurity: deviceSecurity({ state }),
+        requestedAt: "2026-08-14T06:03:00Z",
+      });
+
+      expect(result).toMatchObject({ ok: false, code: "DEVICE_SECURITY_NOT_ACTIVE" });
+    });
+  }
+
+  it("requires device security evidence before requesting Warden authorization", () => {
+    const { bundle, event } = deviceBoundEvent();
+    const result = buildWardenDecisionRequestV1({
+      program: bundle.program,
+      event,
+      representation: representation(),
+      deviceSecurity: deviceSecurity({ evidenceRef: "" }),
+      requestedAt: "2026-08-14T06:03:00Z",
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "DEVICE_SECURITY_EVIDENCE_MISSING" });
+  });
+
+  it("rejects future and expired device security resolutions", () => {
+    const { bundle, event } = deviceBoundEvent();
+    const future = buildWardenDecisionRequestV1({
+      program: bundle.program,
+      event,
+      representation: representation(),
+      deviceSecurity: deviceSecurity({ resolvedAt: "2026-08-14T06:03:01Z" }),
+      requestedAt: "2026-08-14T06:03:00Z",
+    });
+    const expired = buildWardenDecisionRequestV1({
+      program: bundle.program,
+      event,
+      representation: representation(),
+      deviceSecurity: deviceSecurity({ validUntil: "2026-08-14T06:02:59Z" }),
+      requestedAt: "2026-08-14T06:03:00Z",
+    });
+
+    expect(future).toMatchObject({ ok: false, code: "DEVICE_SECURITY_FROM_FUTURE" });
+    expect(expired).toMatchObject({ ok: false, code: "DEVICE_SECURITY_EXPIRED" });
+  });
+
+  it("binds ACTIVE device security evidence into the Warden request identity", () => {
+    const { bundle, event } = deviceBoundEvent();
+    const first = buildWardenDecisionRequestV1({
+      program: bundle.program,
+      event,
+      representation: representation(),
+      deviceSecurity: deviceSecurity(),
+      requestedAt: "2026-08-14T06:03:00Z",
+    });
+    const second = buildWardenDecisionRequestV1({
+      program: bundle.program,
+      event,
+      representation: representation(),
+      deviceSecurity: deviceSecurity({
+        resolutionRef: "REGISTRY-DEVICE-SECURITY:ALPHA-DEVICE-001:ACTIVE:2",
+        evidenceRef: "RIVER-EVIDENCE:BAG-LOCK-ACTIVE-002",
+      }),
+      requestedAt: "2026-08-14T06:03:00Z",
+    });
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    if (!first.ok || !second.ok) return;
+    expect(first.request.executionDeviceRef).toBe("ALPHA-DEVICE-001");
+    expect(first.request.deviceSecurityState).toBe("ACTIVE");
+    expect(first.request.deviceSecurityPolicyRef).toBe("BAG-LOCK-POLICY:ALPHA-001");
+    expect(first.request.deviceSecuritySourceRefs).toEqual([
+      "REGISTRY-DEVICE-SECURITY:ALPHA-DEVICE-001:ACTIVE",
+      "RIVER-EVIDENCE:BAG-LOCK-ACTIVE-001",
+    ]);
+    expect(second.request.requestRef).not.toBe(first.request.requestRef);
+  });
+
+  it("rejects stray device security context on a non-device-bound Event", () => {
+    const bundle = readyPlanningBundle();
+    const result = buildWardenDecisionRequestV1({
+      program: bundle.program,
+      event: bundle.events[0],
+      representation: representation(),
+      deviceSecurity: deviceSecurity(),
+      requestedAt: "2026-08-14T06:03:00Z",
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "DEVICE_SECURITY_CONTEXT_MISMATCH" });
   });
 });

--- a/modules/synnergyze/warden-request-bridge.ts
+++ b/modules/synnergyze/warden-request-bridge.ts
@@ -1,7 +1,11 @@
 import { createHash } from "node:crypto";
 
 import type { WardenDecisionRequestV1 } from "../warden/contracts.ts";
-import type { SynnergyzeEventDraftV1, SynnergyzeProgramDraftV1 } from "./contracts.ts";
+import type {
+  ResolvedDeviceSecurityContextV1,
+  SynnergyzeEventDraftV1,
+  SynnergyzeProgramDraftV1,
+} from "./contracts.ts";
 
 export interface ResolvedRepresentationContextV1 {
   resolutionRef: string;
@@ -19,6 +23,7 @@ export interface WardenRequestBridgeInputV1 {
   program: SynnergyzeProgramDraftV1;
   event: SynnergyzeEventDraftV1;
   representation: ResolvedRepresentationContextV1;
+  deviceSecurity?: ResolvedDeviceSecurityContextV1;
   requestedAt: string;
 }
 
@@ -33,7 +38,14 @@ export type WardenRequestBridgeErrorCodeV1 =
   | "REPRESENTATION_INCOMPLETE"
   | "REPRESENTATION_SOURCE_MISSING"
   | "CAPABILITY_REQUIRED"
-  | "TARGET_REQUIRED";
+  | "TARGET_REQUIRED"
+  | "DEVICE_SECURITY_REQUIRED"
+  | "DEVICE_SECURITY_CONTEXT_MISMATCH"
+  | "DEVICE_SECURITY_NOT_ACTIVE"
+  | "DEVICE_SECURITY_EVIDENCE_MISSING"
+  | "DEVICE_SECURITY_TIME_INVALID"
+  | "DEVICE_SECURITY_FROM_FUTURE"
+  | "DEVICE_SECURITY_EXPIRED";
 
 export interface WardenRequestBridgeFailureV1 {
   ok: false;
@@ -61,6 +73,11 @@ function canonicalRefs(values: readonly string[]): string[] {
   return [...new Set(values.filter(Boolean))].sort();
 }
 
+function parseInstant(value: string): number | undefined {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 function fail(
   code: WardenRequestBridgeErrorCodeV1,
   reason: string,
@@ -79,7 +96,7 @@ function fail(
 export function buildWardenDecisionRequestV1(
   input: WardenRequestBridgeInputV1,
 ): WardenRequestBridgeResultV1 {
-  const { program, event, representation } = input;
+  const { program, event, representation, deviceSecurity } = input;
 
   if (program.state !== "READY_FOR_AUTHORIZATION" || program.authorized !== false) {
     return fail("PROGRAM_NOT_READY", "program_not_ready_for_authorization_request", input);
@@ -145,6 +162,64 @@ export function buildWardenDecisionRequestV1(
     return fail("PROGRAM_EVENT_MISMATCH", "event_program_capability_mismatch", input);
   }
 
+  let deviceSecuritySourceRefs: string[] | undefined;
+  if (event.executionDeviceRef) {
+    if (!deviceSecurity) {
+      return fail("DEVICE_SECURITY_REQUIRED", "device_bound_event_requires_security_resolution", input);
+    }
+    if (deviceSecurity.deviceRef !== event.executionDeviceRef) {
+      return fail(
+        "DEVICE_SECURITY_CONTEXT_MISMATCH",
+        "resolved_device_security_context_belongs_to_another_device",
+        input,
+      );
+    }
+    if (deviceSecurity.state !== "ACTIVE") {
+      return fail(
+        "DEVICE_SECURITY_NOT_ACTIVE",
+        `device_security_state_${deviceSecurity.state.toLowerCase()}`,
+        input,
+      );
+    }
+    if (!deviceSecurity.resolutionRef || !deviceSecurity.evidenceRef) {
+      return fail(
+        "DEVICE_SECURITY_EVIDENCE_MISSING",
+        "device_security_resolution_and_evidence_are_required",
+        input,
+      );
+    }
+
+    const requestedAtMs = parseInstant(input.requestedAt);
+    const resolvedAtMs = parseInstant(deviceSecurity.resolvedAt);
+    const validUntilMs = deviceSecurity.validUntil
+      ? parseInstant(deviceSecurity.validUntil)
+      : undefined;
+    if (
+      requestedAtMs === undefined ||
+      resolvedAtMs === undefined ||
+      (deviceSecurity.validUntil && validUntilMs === undefined)
+    ) {
+      return fail("DEVICE_SECURITY_TIME_INVALID", "device_security_time_context_invalid", input);
+    }
+    if (resolvedAtMs > requestedAtMs) {
+      return fail("DEVICE_SECURITY_FROM_FUTURE", "device_security_resolution_is_from_future", input);
+    }
+    if (validUntilMs !== undefined && requestedAtMs > validUntilMs) {
+      return fail("DEVICE_SECURITY_EXPIRED", "device_security_resolution_expired", input);
+    }
+
+    deviceSecuritySourceRefs = canonicalRefs([
+      deviceSecurity.resolutionRef,
+      deviceSecurity.evidenceRef,
+    ]);
+  } else if (deviceSecurity) {
+    return fail(
+      "DEVICE_SECURITY_CONTEXT_MISMATCH",
+      "device_security_context_supplied_for_non_device_bound_event",
+      input,
+    );
+  }
+
   const authorityRefs = canonicalRefs(representation.authorityRefs);
   const policyRefs = canonicalRefs(representation.policyRefs);
 
@@ -159,6 +234,12 @@ export function buildWardenDecisionRequestV1(
     capabilityRef: event.capabilityRef,
     targetRef: event.targetRef,
     requestedEffect: event.requestedEffect ?? program.requestedEffect ?? null,
+    executionDeviceRef: event.executionDeviceRef ?? null,
+    deviceSecurityState: event.executionDeviceRef ? deviceSecurity?.state : null,
+    deviceSecurityPolicyRef: event.executionDeviceRef ? deviceSecurity?.policyRef ?? null : null,
+    deviceSecuritySourceRefs: deviceSecuritySourceRefs ?? [],
+    deviceSecurityResolvedAt: event.executionDeviceRef ? deviceSecurity?.resolvedAt ?? null : null,
+    deviceSecurityValidUntil: event.executionDeviceRef ? deviceSecurity?.validUntil ?? null : null,
     authorityRefs,
     policyRefs,
     representationSourceRefs,
@@ -179,6 +260,12 @@ export function buildWardenDecisionRequestV1(
     capabilityRef: event.capabilityRef,
     targetRef: event.targetRef,
     requestedEffect: event.requestedEffect ?? program.requestedEffect,
+    executionDeviceRef: event.executionDeviceRef,
+    deviceSecurityState: event.executionDeviceRef ? "ACTIVE" : undefined,
+    deviceSecurityPolicyRef: event.executionDeviceRef ? deviceSecurity?.policyRef : undefined,
+    deviceSecuritySourceRefs,
+    deviceSecurityResolvedAt: event.executionDeviceRef ? deviceSecurity?.resolvedAt : undefined,
+    deviceSecurityValidUntil: event.executionDeviceRef ? deviceSecurity?.validUntil : undefined,
     authorityRefs,
     policyRefs,
     representationSourceRefs,

--- a/modules/warden/contracts.ts
+++ b/modules/warden/contracts.ts
@@ -12,6 +12,12 @@ export interface WardenDecisionRequestV1 {
   capabilityRef: string;
   targetRef: string;
   requestedEffect?: string;
+  executionDeviceRef?: string;
+  deviceSecurityState?: "ACTIVE";
+  deviceSecurityPolicyRef?: string;
+  deviceSecuritySourceRefs?: readonly string[];
+  deviceSecurityResolvedAt?: string;
+  deviceSecurityValidUntil?: string;
   authorityRefs: readonly string[];
   policyRefs: readonly string[];
   representationSourceRefs: readonly string[];

--- a/modules/warden/decision-service.ts
+++ b/modules/warden/decision-service.ts
@@ -58,6 +58,7 @@ function baseDecision(
       authorityRefs: stableUnique(request.authorityRefs),
       policyRefs: stableUnique(request.policyRefs),
       representationSourceRefs: stableUnique(request.representationSourceRefs),
+      deviceSecuritySourceRefs: stableUnique(request.deviceSecuritySourceRefs ?? []),
     },
     policy: {
       ...policy,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:controlled-execution": "vitest run modules/synnergyze/execution-gate.test.ts",
     "test:effect-verification": "vitest run modules/synnergyze/effect-verification.test.ts",
     "test:objective": "vitest run modules/objective/inventory-transfer.test.ts",
+    "test:bag-lock-runtime": "vitest run modules/synnergyze/warden-request-bridge.test.ts modules/synnergyze/execution-gate.test.ts",
     "test:sites": "vitest run api/sites.test.ts",
     "test:site-handoff": "vitest run site-handoff/runtime.test.ts",
     "probe:apple-mpp": "bash scripts/bootstrap-apple-mpp-runner.sh",


### PR DESCRIPTION
## Objective

Port the useful fail-closed semantics from obsolete PR #35 onto the **current governed runtime** without reviving the old Program/Event execution stack.

This implements BAG-LOCK as a hard constraint at two distinct points:

1. **Before Warden request** — a device-bound Event cannot even request authorization unless the exact device resolves `ACTIVE` with Registry/evidence lineage and valid timing.
2. **Immediately before controlled execution** — a fresh device-security resolution is required again, so a device that becomes `SEALED`, `SEALED_ALERT`, `UNSEAL_PENDING`, etc. after authorization still cannot execute.

## Canonical invariant

`AUTHORIZATION-TIME ACTIVE != EXECUTION-TIME ACTIVE`

and:

`BAG OPEN != ACTIVE`

`DEVICE STATE != IDENTITY != SESSION != AUTHORITY`

## Changes

- `modules/synnergyze/contracts.ts`
  - adds BAG-LOCK device states, L0–L4 assurance vocabulary, `ResolvedDeviceSecurityContextV1`, optional `executionDeviceRef`, and execution-receipt security lineage.
- `modules/synnergyze/warden-request-bridge.ts`
  - fails closed for missing/mismatched/non-ACTIVE/future/expired/un-evidenced device security on device-bound events;
  - binds exact security evidence into the Warden request identity;
  - rejects stray device context on non-device-bound events.
- `modules/warden/contracts.ts` / `decision-service.ts`
  - carries provider-neutral device-security request bindings and canonicalizes source refs into Warden decision identity.
- `modules/river/contracts.ts` / `reservation-service.ts`
  - carries a digest of the request-time device-security binding in the authorized Action envelope;
  - River reservation exact-action checks therefore preserve the device-security-authorized request identity.
- `modules/synnergyze/execution-gate.ts`
  - requires a fresh matching `ACTIVE` device-security context before adapter invocation when the Action is device-bound;
  - checks evidence, policy, resolution timing and expiry;
  - includes the fresh security checkpoint in execution idempotency identity;
  - carries security evidence lineage into the unverified execution receipt.
- focused tests cover pre-Warden and execution-time fail-closed states, device mismatch, missing evidence, policy drift, future/expired security state, identical replay, and conflicting replay.
- `.vsr/repository-components.yaml` records BAG-LOCK guards while explicitly prohibiting any claim that Synnergyze itself enforces hardware ports/radios.

## Hard boundary

This PR does **not**:
- close a physical USB/radio interface;
- claim L2/L3/L4 hardware assurance;
- make Registry state into authority;
- let Synnergyze replace Warden;
- activate a live Alpha/Linux host;
- satisfy L-010 without SentinelX/host/recovery/lab evidence.

Genesis/device substrate remains the enforcement layer. Registry/context resolution supplies the referenced state/evidence; Warden remains authority; Synnergyze only enforces the state as a precondition to governed execution.

Supersedes the runtime intent of old PR #35 once merged. Related: `SynergyzeGovernance#19`, `#20`.