### PR TITLE
AF-004 — bind Warden-issued Agent proposals to governed Action Gateway

### DIFF
--- a/agent-fabric/action-gateway.test.ts
+++ b/agent-fabric/action-gateway.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  AGENT_RC1_IDENTITIES,
+  AgentRuntime,
+  DeterministicModelAdapter,
+  SyntheticWardenAgentAuthority,
+} from "./runtime.ts";
+import type { ModelInvocationProposal, WardenAuthorityEnvelope } from "./runtime.ts";
+import { AgentActionGatewayBridgeV1, type AgentActionContextV1 } from "./action-gateway.ts";
+
+const ISSUED_AT = "2026-08-13T07:10:00.000Z";
+const REVOKED_AT = "2026-08-13T07:12:00.000Z";
+
+const modelA = new DeterministicModelAdapter({
+  adapterRef: "MODEL-ADAPTER-A-001",
+  providerRef: "SYNTHETIC-PROVIDER-A",
+  modelRef: "SYNTHETIC-MODEL-A",
+});
+const modelB = new DeterministicModelAdapter({
+  adapterRef: "MODEL-ADAPTER-B-001",
+  providerRef: "SYNTHETIC-PROVIDER-B",
+  modelRef: "SYNTHETIC-MODEL-B",
+});
+
+function activateRuntime(): {
+  warden: SyntheticWardenAgentAuthority;
+  envelope: WardenAuthorityEnvelope;
+  runtime: AgentRuntime;
+} {
+  const warden = new SyntheticWardenAgentAuthority();
+  const issuance = warden.issue({
+    requesterRef: AGENT_RC1_IDENTITIES.requesterRef,
+    representedEntityRef: AGENT_RC1_IDENTITIES.representedEntityRef,
+    packRef: AGENT_RC1_IDENTITIES.packRef,
+    requestedAgentId: AGENT_RC1_IDENTITIES.agentId,
+    requestedIssuanceId: AGENT_RC1_IDENTITIES.issuanceId,
+    requestedCapabilities: ["entity.profile.read", "service_request.create"],
+    requestedAt: ISSUED_AT,
+  });
+  if (!issuance.envelope) throw new Error("test_agent_issuance_missing");
+  const envelope = issuance.envelope;
+  const bindingDecision = warden.authorizeBindingChange(
+    envelope,
+    modelA.adapterRef,
+    "WARDEN-MODEL-BINDING-A-AF004",
+  );
+  const runtime = AgentRuntime.activate({
+    issuance: envelope,
+    initialBindingRef: AGENT_RC1_IDENTITIES.modelABindingRef,
+    initialBindingDecision: bindingDecision,
+    adapterRegistry: [modelA, modelB],
+    purpose: "company-base-agent",
+    capabilityProfile: envelope.allowedCapabilities,
+    activatedAt: ISSUED_AT,
+    idempotencyKey: "AF004-BIND-A-001",
+  });
+  runtime.openSession({ sessionId: "AF004-SESSION-001", openedAt: ISSUED_AT });
+  return { warden, envelope, runtime };
+}
+
+function proposal(runtime: AgentRuntime, capability: string): ModelInvocationProposal {
+  return runtime.invoke({
+    sessionId: "AF004-SESSION-001",
+    prompt: `propose ${capability}`,
+    requestedCapability: capability,
+  });
+}
+
+function context(
+  capability: "service_request.create" | "contract.execute",
+  correlationId = capability === "service_request.create" ? "AF004-CORR-ALLOW-001" : "AF004-CORR-DENY-001",
+): AgentActionContextV1 {
+  return {
+    actorRef: AGENT_RC1_IDENTITIES.requesterRef,
+    representedEntityRef: AGENT_RC1_IDENTITIES.representedEntityRef,
+    actingCapacityRef: "CAPACITY:LAB-OPERATOR-001",
+    programRef: "ALPHA-RC1-PROGRAM-001",
+    targetRef: capability === "service_request.create" ? "LAB-SERVICE-DESK-001" : "LAB-CONTRACT-001",
+    correlationId,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AF-004 Agent proposal to governed Action Gateway", () => {
+  it("executes one allowed Agent proposal only after a separate Warden decision and River reservation", () => {
+    const { runtime } = activateRuntime();
+    const modelProposal = proposal(runtime, "service_request.create");
+    const bridge = new AgentActionGatewayBridgeV1();
+
+    expect(modelProposal.authorized).toBe(false);
+    expect(modelProposal.actionToken).toBeUndefined();
+
+    const result = bridge.execute({
+      runtime,
+      proposal: modelProposal,
+      context: context("service_request.create"),
+    });
+
+    expect(result.intent.authorized).toBe(false);
+    expect(result.intent.actionToken).toBeUndefined();
+    expect(result.causalEnvelope.resultState).toBe("VERIFIED_EFFECT");
+    expect(result.causalEnvelope.proposalRef).toBe(modelProposal.proposalRef);
+    expect(result.causalEnvelope.agentId).toBe(AGENT_RC1_IDENTITIES.agentId);
+    expect(result.causalEnvelope.issuanceId).toBe(AGENT_RC1_IDENTITIES.issuanceId);
+    expect(result.causalEnvelope.modelBindingRef).toBe(modelProposal.bindingRef);
+    expect(result.causalEnvelope.actionTokenPresent).toBe(true);
+    expect(result.causalEnvelope.wardenDecisionRef).toMatch(/^RC1-WARDEN-DECISION:/);
+    expect(result.causalEnvelope.riverReservationRef).toMatch(/^RC1-EVIDENCE-RESERVATION:/);
+    expect(result.causalEnvelope.connectorReceiptRef).toMatch(/^RC1-RECEIPT:/);
+    expect(result.causalEnvelope.serviceRequestRef).toMatch(/^RC1-SERVICE-REQUEST:/);
+    expect(result.causalEnvelope.riverSealRef).toMatch(/^RC1-EVIDENCE-SEALED:/);
+    expect(result.causalEnvelope.effectRef).toMatch(/^RC1-EFFECT:/);
+    expect(bridge.gatewayRequestCount()).toBe(1);
+  });
+
+  it("denies contract.execute with no token, connector mutation, seal or effect", () => {
+    const { runtime } = activateRuntime();
+    const bridge = new AgentActionGatewayBridgeV1();
+    const result = bridge.execute({
+      runtime,
+      proposal: proposal(runtime, "contract.execute"),
+      context: context("contract.execute"),
+    });
+
+    expect(result.causalEnvelope.resultState).toBe("DENIED");
+    expect(result.causalEnvelope.actionTokenPresent).toBe(false);
+    expect(result.causalEnvelope.riverDeniedOrExceptionRef).toMatch(/^RC1-EVIDENCE-DENIED:/);
+    expect(result.causalEnvelope.riverReservationRef).toBeUndefined();
+    expect(result.causalEnvelope.connectorReceiptRef).toBeUndefined();
+    expect(result.causalEnvelope.riverSealRef).toBeUndefined();
+    expect(result.causalEnvelope.effectRef).toBeUndefined();
+    expect(bridge.gatewayRequestCount()).toBe(0);
+  });
+
+  it("rejects a model-produced or self-declared action token", () => {
+    const { runtime } = activateRuntime();
+    const bridge = new AgentActionGatewayBridgeV1();
+    const tampered = {
+      ...proposal(runtime, "service_request.create"),
+      actionToken: "MODEL-MINTED-TOKEN",
+    } as unknown as ModelInvocationProposal;
+
+    expect(() =>
+      bridge.execute({ runtime, proposal: tampered, context: context("service_request.create") }),
+    ).toThrow("agent_model_self_declared_action_token_rejected");
+    expect(bridge.gatewayRequestCount()).toBe(0);
+  });
+
+  it("rejects Agent, issuance, represented entity, target and binding drift before Warden/execution", () => {
+    const mutations: Array<[string, (proposalValue: ModelInvocationProposal, ctx: AgentActionContextV1) => void]> = [
+      ["agent_action_agent_identity_mismatch", (value) => Object.assign(value, { agentId: "AGENT-IMPOSTOR-001" })],
+      ["agent_action_issuance_mismatch", (value) => Object.assign(value, { issuanceId: "ISSUANCE-IMPOSTOR-001" })],
+      ["agent_action_represented_entity_mismatch", (_value, ctx) => Object.assign(ctx, { representedEntityRef: "ENTITY-IMPOSTOR-001" })],
+      ["agent_action_target_mismatch", (_value, ctx) => Object.assign(ctx, { targetRef: "LAB-WRONG-TARGET-001" })],
+      ["agent_action_binding_not_in_agent_lineage", (value) => Object.assign(value, { bindingRef: "MODEL-BINDING-IMPOSTOR-001" })],
+    ];
+
+    for (const [error, mutate] of mutations) {
+      const { runtime } = activateRuntime();
+      const bridge = new AgentActionGatewayBridgeV1();
+      const value = { ...proposal(runtime, "service_request.create") };
+      const ctx = { ...context("service_request.create") };
+      mutate(value, ctx);
+      expect(() => bridge.execute({ runtime, proposal: value, context: ctx })).toThrow(error);
+      expect(bridge.gatewayRequestCount()).toBe(0);
+    }
+  });
+
+  it("blocks execution when River evidence reservation is missing", () => {
+    const { runtime } = activateRuntime();
+    const bridge = new AgentActionGatewayBridgeV1();
+    const result = bridge.execute({
+      runtime,
+      proposal: proposal(runtime, "service_request.create"),
+      context: context("service_request.create"),
+      options: { omitEvidenceReservation: true },
+    });
+
+    expect(result.causalEnvelope.resultState).toBe("BLOCKED_REQUIREMENT");
+    expect(result.causalEnvelope.actionTokenPresent).toBe(true);
+    expect(result.causalEnvelope.riverReservationRef).toBeUndefined();
+    expect(result.causalEnvelope.connectorReceiptRef).toBeUndefined();
+    expect(result.causalEnvelope.effectRef).toBeUndefined();
+    expect(bridge.gatewayRequestCount()).toBe(0);
+  });
+
+  it("turns a read-after-write mismatch into EXCEPTION and never records a verified effect", () => {
+    const { runtime } = activateRuntime();
+    const bridge = new AgentActionGatewayBridgeV1();
+    const result = bridge.execute({
+      runtime,
+      proposal: proposal(runtime, "service_request.create"),
+      context: context("service_request.create"),
+      options: { injectReadMismatch: true },
+    });
+
+    expect(result.causalEnvelope.resultState).toBe("EXCEPTION");
+    expect(result.causalEnvelope.connectorReceiptRef).toMatch(/^RC1-RECEIPT:/);
+    expect(result.causalEnvelope.riverDeniedOrExceptionRef).toMatch(/^RC1-EVIDENCE-EXCEPTION:/);
+    expect(result.causalEnvelope.riverSealRef).toBeUndefined();
+    expect(result.causalEnvelope.effectRef).toBeUndefined();
+    expect(bridge.gatewayRequestCount()).toBe(1);
+  });
+
+  it("replays the exact proposal idempotently without duplicating the gateway effect", () => {
+    const { runtime } = activateRuntime();
+    const bridge = new AgentActionGatewayBridgeV1();
+    const modelProposal = proposal(runtime, "service_request.create");
+    const ctx = context("service_request.create");
+    const first = bridge.execute({ runtime, proposal: modelProposal, context: ctx });
+    const second = bridge.execute({ runtime, proposal: modelProposal, context: ctx });
+
+    expect(second.causalEnvelope.effectRef).toBe(first.causalEnvelope.effectRef);
+    expect(second.causalEnvelope.connectorReceiptRef).toBe(first.causalEnvelope.connectorReceiptRef);
+    expect(second.causalEnvelope.idempotentReplay).toBe(true);
+    expect(bridge.gatewayRequestCount()).toBe(1);
+    expect(bridge.riverEntries().filter((entry) => entry.stage === "SEALED")).toHaveLength(1);
+  });
+
+  it("rejects changed context under the same proposal and another proposal under the same correlation", () => {
+    const { runtime } = activateRuntime();
+    const bridge = new AgentActionGatewayBridgeV1();
+    const firstProposal = proposal(runtime, "service_request.create");
+    const firstContext = context("service_request.create");
+    bridge.execute({ runtime, proposal: firstProposal, context: firstContext });
+
+    expect(() =>
+      bridge.execute({
+        runtime,
+        proposal: firstProposal,
+        context: { ...firstContext, actingCapacityRef: "CAPACITY:DIFFERENT-001" },
+      }),
+    ).toThrow("agent_action_proposal_idempotency_conflict");
+
+    const secondProposal = proposal(runtime, "service_request.create");
+    expect(() =>
+      bridge.execute({ runtime, proposal: secondProposal, context: firstContext }),
+    ).toThrow("agent_action_correlation_conflict");
+    expect(bridge.gatewayRequestCount()).toBe(1);
+  });
+
+  it("rechecks runtime state and blocks a pre-revocation proposal after revocation", () => {
+    const { warden, envelope, runtime } = activateRuntime();
+    const bridge = new AgentActionGatewayBridgeV1();
+    const prepared = proposal(runtime, "service_request.create");
+    const revocation = warden.revoke(envelope, {
+      decisionRef: "WARDEN-AGENT-REVOCATION-AF004",
+      revokedAt: REVOKED_AT,
+      reason: "synthetic_af004_revocation",
+    });
+    runtime.applyRevocation(revocation);
+
+    expect(() =>
+      bridge.execute({ runtime, proposal: prepared, context: context("service_request.create") }),
+    ).toThrow("agent_runtime_not_active");
+    expect(bridge.gatewayRequestCount()).toBe(0);
+  });
+
+  it("does not use external network/provider calls in the conformance path", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      throw new Error("external_network_forbidden_in_af004");
+    });
+    const { runtime } = activateRuntime();
+    const bridge = new AgentActionGatewayBridgeV1();
+    bridge.execute({
+      runtime,
+      proposal: proposal(runtime, "service_request.create"),
+      context: context("service_request.create"),
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/agent-fabric/action-gateway.ts
+++ b/agent-fabric/action-gateway.ts
@@ -1,0 +1,326 @@
+import { createHash } from "node:crypto";
+
+import type {
+  AgentRuntime,
+  ModelInvocationProposal,
+  WardenAuthorityEnvelope,
+} from "./runtime.ts";
+import {
+  AlphaRc1Harness,
+  type Rc1ActionAttemptResult,
+  type Rc1Capability,
+  type Rc1EvidenceEntry,
+} from "../rc1/runtime.ts";
+
+export interface AgentActionContextV1 {
+  actorRef: string;
+  representedEntityRef: string;
+  actingCapacityRef: string;
+  programRef: "ALPHA-RC1-PROGRAM-001";
+  targetRef: string;
+  correlationId: string;
+}
+
+export interface AgentActionIntentV1 {
+  intentRef: string;
+  proposalRef: string;
+  agentId: string;
+  issuanceId: string;
+  modelBindingRef: string;
+  modelRef: string;
+  actorRef: string;
+  representedEntityRef: string;
+  actingCapacityRef: string;
+  programRef: "ALPHA-RC1-PROGRAM-001";
+  capability: Rc1Capability;
+  targetRef: string;
+  correlationId: string;
+  authorized: false;
+  actionToken?: undefined;
+}
+
+export type AgentControlledActionStateV1 =
+  | "VERIFIED_EFFECT"
+  | "DENIED"
+  | "BLOCKED_REQUIREMENT"
+  | "EXCEPTION";
+
+export interface AgentActionCausalEnvelopeV1 {
+  proposalRef: string;
+  intentRef: string;
+  agentId: string;
+  issuanceId: string;
+  modelBindingRef: string;
+  modelRef: string;
+  actorRef: string;
+  representedEntityRef: string;
+  capability: Rc1Capability;
+  correlationRef: string;
+  wardenDecisionRef?: string;
+  actionTokenPresent: boolean;
+  riverReservationRef?: string;
+  riverSealRef?: string;
+  riverDeniedOrExceptionRef?: string;
+  connectorReceiptRef?: string;
+  serviceRequestRef?: string;
+  effectRef?: string;
+  resultState: AgentControlledActionStateV1;
+  idempotentReplay: boolean;
+  synthetic: true;
+}
+
+export interface AgentControlledActionResultV1 {
+  intent: AgentActionIntentV1;
+  causalEnvelope: AgentActionCausalEnvelopeV1;
+}
+
+interface ProposalMemoV1 {
+  fingerprint: string;
+  result: AgentControlledActionResultV1;
+}
+
+function digest(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function proposalFingerprint(
+  proposal: ModelInvocationProposal,
+  context: AgentActionContextV1,
+): string {
+  return digest(
+    JSON.stringify({
+      proposalRef: proposal.proposalRef,
+      sessionId: proposal.sessionId,
+      agentId: proposal.agentId,
+      issuanceId: proposal.issuanceId,
+      bindingRef: proposal.bindingRef,
+      modelRef: proposal.modelRef,
+      requestedCapability: proposal.requestedCapability,
+      output: proposal.output,
+      context,
+    }),
+  );
+}
+
+function cloneResult(result: AgentControlledActionResultV1): AgentControlledActionResultV1 {
+  return {
+    intent: { ...result.intent },
+    causalEnvelope: { ...result.causalEnvelope },
+  };
+}
+
+function mapCapability(capability: string): Rc1Capability {
+  if (capability === "service_request.create" || capability === "contract.execute") {
+    return capability;
+  }
+  throw new Error(`agent_action_capability_not_supported:${capability}`);
+}
+
+function evidenceForCorrelation(
+  entries: readonly Rc1EvidenceEntry[],
+  correlationId: string,
+): Rc1EvidenceEntry[] {
+  return entries.filter((entry) => entry.correlationId === correlationId);
+}
+
+function assertProposalIsUnauthorized(proposal: ModelInvocationProposal): void {
+  const unsafe = proposal as ModelInvocationProposal & {
+    authorized?: unknown;
+    actionToken?: unknown;
+  };
+  if (unsafe.authorized !== false) {
+    throw new Error("agent_model_proposal_must_be_unauthorized");
+  }
+  if (unsafe.actionToken !== undefined) {
+    throw new Error("agent_model_self_declared_action_token_rejected");
+  }
+  if (proposal.requiresWardenDecision !== true) {
+    throw new Error("agent_proposal_warden_decision_required");
+  }
+}
+
+function assertProposalBoundToRuntime(
+  runtime: AgentRuntime,
+  proposal: ModelInvocationProposal,
+  context: AgentActionContextV1,
+  issuance: WardenAuthorityEnvelope,
+): void {
+  if (runtime.state() !== "ACTIVE") {
+    throw new Error("agent_runtime_not_active");
+  }
+  if (proposal.agentId !== issuance.agentId) {
+    throw new Error("agent_action_agent_identity_mismatch");
+  }
+  if (proposal.issuanceId !== issuance.issuanceId) {
+    throw new Error("agent_action_issuance_mismatch");
+  }
+  if (context.actorRef !== issuance.requesterRef) {
+    throw new Error("agent_action_requester_mismatch");
+  }
+  if (context.representedEntityRef !== issuance.representedEntityRef) {
+    throw new Error("agent_action_represented_entity_mismatch");
+  }
+
+  const binding = runtime
+    .bindingHistory()
+    .find((candidate) => candidate.bindingRef === proposal.bindingRef);
+  if (!binding) {
+    throw new Error("agent_action_binding_not_in_agent_lineage");
+  }
+  if (
+    binding.agentId !== issuance.agentId ||
+    binding.issuanceId !== issuance.issuanceId ||
+    binding.representedEntityRef !== issuance.representedEntityRef ||
+    binding.modelRef !== proposal.modelRef ||
+    binding.authorityFingerprint !== issuance.authorityFingerprint
+  ) {
+    throw new Error("agent_action_binding_identity_or_authority_drift");
+  }
+
+  if (!issuance.allowedCapabilities.includes(proposal.requestedCapability)) {
+    if (!issuance.deniedCapabilities.includes(proposal.requestedCapability)) {
+      throw new Error("agent_action_capability_outside_issuance");
+    }
+  }
+}
+
+function actionIntent(
+  proposal: ModelInvocationProposal,
+  context: AgentActionContextV1,
+): AgentActionIntentV1 {
+  const capability = mapCapability(proposal.requestedCapability);
+  const identity = digest(
+    [
+      proposal.proposalRef,
+      proposal.agentId,
+      proposal.issuanceId,
+      proposal.bindingRef,
+      context.actorRef,
+      context.representedEntityRef,
+      context.actingCapacityRef,
+      context.programRef,
+      capability,
+      context.targetRef,
+      context.correlationId,
+    ].join("|"),
+  ).slice(0, 24);
+
+  return {
+    intentRef: `AGENT-ACTION-INTENT:${identity}`,
+    proposalRef: proposal.proposalRef,
+    agentId: proposal.agentId,
+    issuanceId: proposal.issuanceId,
+    modelBindingRef: proposal.bindingRef,
+    modelRef: proposal.modelRef,
+    actorRef: context.actorRef,
+    representedEntityRef: context.representedEntityRef,
+    actingCapacityRef: context.actingCapacityRef,
+    programRef: context.programRef,
+    capability,
+    targetRef: context.targetRef,
+    correlationId: context.correlationId,
+    authorized: false,
+    actionToken: undefined,
+  };
+}
+
+function resultState(result: Rc1ActionAttemptResult): AgentControlledActionStateV1 {
+  if (result.status === "VERIFIED") return "VERIFIED_EFFECT";
+  if (result.status === "DENIED" || result.status === "MISSING_AUTHORIZATION") return "DENIED";
+  if (result.status === "BLOCKED_REQUIREMENT") return "BLOCKED_REQUIREMENT";
+  return "EXCEPTION";
+}
+
+export class AgentActionGatewayBridgeV1 {
+  private readonly harness: AlphaRc1Harness;
+  private readonly proposalMemos = new Map<string, ProposalMemoV1>();
+  private readonly proposalRefByCorrelation = new Map<string, string>();
+
+  constructor(harness = new AlphaRc1Harness()) {
+    this.harness = harness;
+  }
+
+  execute(input: {
+    runtime: AgentRuntime;
+    proposal: ModelInvocationProposal;
+    context: AgentActionContextV1;
+    options?: {
+      omitEvidenceReservation?: boolean;
+      injectReadMismatch?: boolean;
+    };
+  }): AgentControlledActionResultV1 {
+    const { runtime, proposal, context } = input;
+    const issuance = runtime.authorityEnvelope();
+
+    assertProposalIsUnauthorized(proposal);
+    assertProposalBoundToRuntime(runtime, proposal, context, issuance);
+
+    const fingerprint = proposalFingerprint(proposal, context);
+    const existing = this.proposalMemos.get(proposal.proposalRef);
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) {
+        throw new Error("agent_action_proposal_idempotency_conflict");
+      }
+      return {
+        ...cloneResult(existing.result),
+        causalEnvelope: {
+          ...existing.result.causalEnvelope,
+          idempotentReplay: true,
+        },
+      };
+    }
+
+    const correlatedProposal = this.proposalRefByCorrelation.get(context.correlationId);
+    if (correlatedProposal && correlatedProposal !== proposal.proposalRef) {
+      throw new Error("agent_action_correlation_conflict");
+    }
+
+    const intent = actionIntent(proposal, context);
+    const attempt = this.harness.attempt(intent.capability, context.correlationId, {
+      omitEvidenceReservation: input.options?.omitEvidenceReservation,
+      injectReadMismatch: input.options?.injectReadMismatch,
+    });
+    const evidence = evidenceForCorrelation(this.harness.riverEntries(), context.correlationId);
+    const reservation = evidence.find((entry) => entry.stage === "RESERVED");
+    const seal = evidence.find((entry) => entry.stage === "SEALED");
+    const deniedOrException = [...evidence]
+      .reverse()
+      .find((entry) => entry.stage === "DENIED" || entry.stage === "EXCEPTION");
+
+    const causalEnvelope: AgentActionCausalEnvelopeV1 = {
+      proposalRef: proposal.proposalRef,
+      intentRef: intent.intentRef,
+      agentId: proposal.agentId,
+      issuanceId: proposal.issuanceId,
+      modelBindingRef: proposal.bindingRef,
+      modelRef: proposal.modelRef,
+      actorRef: context.actorRef,
+      representedEntityRef: context.representedEntityRef,
+      capability: intent.capability,
+      correlationRef: context.correlationId,
+      wardenDecisionRef: attempt.decision?.decisionRef,
+      actionTokenPresent: Boolean(attempt.decision?.actionToken),
+      riverReservationRef: reservation?.evidenceRef,
+      riverSealRef: seal?.evidenceRef,
+      riverDeniedOrExceptionRef: deniedOrException?.evidenceRef,
+      connectorReceiptRef: attempt.receipt?.receiptRef,
+      serviceRequestRef: attempt.receipt?.serviceRequestRef,
+      effectRef: attempt.effectRef,
+      resultState: resultState(attempt),
+      idempotentReplay: Boolean(attempt.receipt?.idempotentReplay),
+      synthetic: true,
+    };
+    const result = { intent, causalEnvelope };
+    this.proposalMemos.set(proposal.proposalRef, { fingerprint, result: cloneResult(result) });
+    this.proposalRefByCorrelation.set(context.correlationId, proposal.proposalRef);
+    return cloneResult(result);
+  }
+
+  gatewayRequestCount(): number {
+    return this.harness.gatewayRequestCount();
+  }
+
+  riverEntries(): Rc1EvidenceEntry[] {
+    return this.harness.riverEntries();
+  }
+}

--- a/agent-fabric/action-gateway.ts
+++ b/agent-fabric/action-gateway.ts
@@ -54,6 +54,8 @@ export interface AgentActionCausalEnvelopeV1 {
   modelRef: string;
   actorRef: string;
   representedEntityRef: string;
+  actingCapacityRef: string;
+  targetRef: string;
   capability: Rc1Capability;
   correlationRef: string;
   wardenDecisionRef?: string;
@@ -116,6 +118,10 @@ function mapCapability(capability: string): Rc1Capability {
   throw new Error(`agent_action_capability_not_supported:${capability}`);
 }
 
+function expectedRc1Target(capability: Rc1Capability): string {
+  return capability === "service_request.create" ? "LAB-SERVICE-DESK-001" : "LAB-CONTRACT-001";
+}
+
 function evidenceForCorrelation(
   entries: readonly Rc1EvidenceEntry[],
   correlationId: string,
@@ -159,6 +165,11 @@ function assertProposalBoundToRuntime(
   }
   if (context.representedEntityRef !== issuance.representedEntityRef) {
     throw new Error("agent_action_represented_entity_mismatch");
+  }
+
+  const capability = mapCapability(proposal.requestedCapability);
+  if (context.targetRef !== expectedRc1Target(capability)) {
+    throw new Error("agent_action_target_mismatch");
   }
 
   const binding = runtime
@@ -296,6 +307,8 @@ export class AgentActionGatewayBridgeV1 {
       modelRef: proposal.modelRef,
       actorRef: context.actorRef,
       representedEntityRef: context.representedEntityRef,
+      actingCapacityRef: context.actingCapacityRef,
+      targetRef: context.targetRef,
       capability: intent.capability,
       correlationRef: context.correlationId,
       wardenDecisionRef: attempt.decision?.decisionRef,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:compute": "vitest run api/compute-plane.test.ts compute/runtime.test.ts",
     "test:compute-proof": "vitest run compute/runtime.test.ts",
     "test:agent": "vitest run agent-fabric/runtime.test.ts",
+    "test:agent-action": "vitest run agent-fabric/action-gateway.test.ts",
     "test:contracts": "vitest run modules/contracts.test.ts",
     "test:adapters": "vitest run modules/rc1-adapters.test.ts",
     "test:qel": "vitest run modules/qel/normalizer.test.ts",


### PR DESCRIPTION
## Scope

Implements Linear ESO-60 / Governance AF-004 without creating a second Action Gateway.

Canonical chain:

`Agent model proposal (unauthorized/tokenless) → exact Agent Action Intent → RC1 Warden decision → River reservation → existing RC1 InMemoryActionGateway → read-after-write verification → River seal → Agent causal envelope`

## Reuse

This bridge reuses `AlphaRc1Harness`, which owns the existing deterministic RC1 Warden, `SyntheticRiverEvidence`, and `InMemoryActionGateway`. No parallel connector/execution engine is introduced.

## Agent binding added

`agent-fabric/action-gateway.ts` requires and verifies:
- Warden-issued Agent runtime is still ACTIVE at execution time;
- exact `agentId` + `issuanceId`;
- requester/actor and represented entity;
- proposal model binding belongs to the Agent lineage and retains the same authority fingerprint;
- exact RC1 target for the proposed capability;
- model proposal is still `authorized:false`, `requiresWardenDecision:true`, and carries no action token;
- capability is either within issuance allow scope or an explicitly denied capability that must reach the Warden deny path.

The emitted Agent Action Intent remains unauthorized/tokenless. Warden authorization is separate.

## Causal envelope

Preserves proposal, Agent/issuance/model-binding, actor/entity/capacity/target/capability/correlation, Warden decision, token presence/absence, River reservation/seal/deny/exception refs, connector receipt, service-request ref, Effect ref, result state and replay state.

## Conformance tests

`agent-fabric/action-gateway.test.ts` proves:
- allowed `service_request.create` executes exactly once only after Warden + River gating;
- forbidden `contract.execute` produces zero gateway/effect mutation;
- model-minted token rejected;
- Agent / issuance / represented entity / target / binding drift rejected before execution;
- missing evidence reservation blocks execution;
- read-after-write mismatch becomes EXCEPTION, never Effect;
- exact replay is idempotent with one gateway Effect;
- conflicting proposal/correlation replay rejected;
- a proposal prepared before revocation cannot execute after revocation;
- no external network/provider calls.

## Hard boundary

Synthetic conformance only. No Supabase/Neon requirement, real provider call, financial/legal effect, production Warden activation, or settlement semantics.

Promotion requires full repository test/lint/type-check/bridge CI on the exact head.