### PR TITLE
GCS-20260816-001: rebase governed Registry provisioning onto current Warden contracts

### DIFF
--- a/modules/synnergyze/registry-provisioning.test.ts
+++ b/modules/synnergyze/registry-provisioning.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+
+import type { WardenDecisionV1 } from "../warden/contracts.ts";
+import {
+  evaluateRegistryGateProposalV1,
+  type GateDeclareRequestV1,
+  type SentinelTemporalConditionV1,
+} from "./registry-provisioning.ts";
+
+const request: GateDeclareRequestV1 = {
+  envelope: {
+    commandRef: "REGISTRY-COMMAND:CLDR-V49-DATA-SLUSH",
+    commandType: "GATE_DECLARE",
+    subjectRef: "CLDR-V49-2026-DATA_SLUSH",
+    actorRef: "DM-TEST-001",
+    actingCapacityRef: "RELEASE_MANAGER",
+    evidenceRefs: ["EVIDENCE-SET-CLDR-V49-DATA-SLUSH"],
+    correlationId: "CORRELATION:CLDR-V49-DATA-SLUSH",
+    idempotencyKey: "cldr-v49-data-slush-declare",
+  },
+  gateEventRef: "CLDR-V49-2026-DATA_SLUSH",
+  evidenceSetRef: "EVIDENCE-SET-CLDR-V49-DATA-SLUSH",
+};
+
+const temporal: SentinelTemporalConditionV1 = {
+  conditionRef: "SENTINEL-CONDITION:CLDR-V49-DATA-SLUSH",
+  conditionType: "DEADLINE_DUE",
+  subjectRef: "CLDR-V49-2026-DATA_SLUSH",
+  observedAt: "2026-08-16T03:30:00Z",
+  source: "SENTINEL_CLOCK",
+};
+
+const allowDecision: WardenDecisionV1 = {
+  decisionRef: "WARDEN-DECISION:CLDR-V49-DATA-SLUSH",
+  requestRef: request.envelope.commandRef,
+  wardenRef: "WARDEN-RUNTIME-001",
+  decision: "ALLOW",
+  action: "registry.gate.declare",
+  targetRef: request.gateEventRef,
+  reasonCodes: ["AUTHORITY_VERIFIED"],
+  constraints: ["EXECUTION_CHECKPOINT_REQUIRED"],
+  decidedAt: "2026-08-16T03:31:00Z",
+  validUntil: "2026-08-16T03:41:00Z",
+  correlationId: request.envelope.correlationId,
+  actionToken: "test-action-token-not-for-production",
+};
+
+const evaluatedAt = "2026-08-16T03:32:00Z";
+
+describe("Synnergyze Registry provisioning proposal boundary", () => {
+  it("does not turn a Sentinel temporal fact into Warden authority", () => {
+    const result = evaluateRegistryGateProposalV1({
+      request,
+      temporalCondition: temporal,
+      evidenceSatisfied: true,
+      evaluatedAt,
+    });
+
+    expect(result).toEqual({
+      disposition: "REQUIRE_AUTHORITY",
+      reason: "SENTINEL_FACT_PRESENT_BUT_WARDEN_DECISION_REQUIRED",
+    });
+  });
+
+  it("preserves a Warden denial even when evidence and time conditions are satisfied", () => {
+    const decision: WardenDecisionV1 = {
+      ...allowDecision,
+      decision: "DENY",
+      reasonCodes: ["REQUIREMENTS_NOT_MET"],
+      actionToken: undefined as never,
+    };
+
+    const result = evaluateRegistryGateProposalV1({
+      request,
+      decision,
+      temporalCondition: temporal,
+      evidenceSatisfied: true,
+      evaluatedAt,
+    });
+
+    expect(result).toEqual({ disposition: "DENIED", reason: "WARDEN_DENIED" });
+  });
+
+  it("requires renewed authority when Warden escalates", () => {
+    const decision: WardenDecisionV1 = {
+      ...allowDecision,
+      decision: "ESCALATE",
+      reasonCodes: ["SEPARATE_AUTHORITY_REQUIRED"],
+      actionToken: undefined as never,
+    };
+
+    const result = evaluateRegistryGateProposalV1({
+      request,
+      decision,
+      temporalCondition: temporal,
+      evidenceSatisfied: true,
+      evaluatedAt,
+    });
+
+    expect(result).toEqual({
+      disposition: "REQUIRE_AUTHORITY",
+      reason: "WARDEN_ESCALATION_REQUIRED",
+    });
+  });
+
+  it("does not produce proposals when mandatory evidence is missing", () => {
+    const result = evaluateRegistryGateProposalV1({
+      request,
+      decision: allowDecision,
+      temporalCondition: temporal,
+      evidenceSatisfied: false,
+      evaluatedAt,
+    });
+
+    expect(result.disposition).toBe("REQUIRE_EVIDENCE");
+    expect(result.transitionProposal).toBeUndefined();
+    expect(result.outboxProposal).toBeUndefined();
+  });
+
+  it("rejects a Warden decision bound to the wrong target", () => {
+    const result = evaluateRegistryGateProposalV1({
+      request,
+      decision: { ...allowDecision, targetRef: "OTHER-GATE" },
+      temporalCondition: temporal,
+      evidenceSatisfied: true,
+      evaluatedAt,
+    });
+
+    expect(result).toEqual({ disposition: "DENIED", reason: "WARDEN_TARGET_MISMATCH" });
+  });
+
+  it("requires renewed authority after the Warden decision expires", () => {
+    const result = evaluateRegistryGateProposalV1({
+      request,
+      decision: allowDecision,
+      temporalCondition: temporal,
+      evidenceSatisfied: true,
+      evaluatedAt: "2026-08-16T03:42:00Z",
+    });
+
+    expect(result).toEqual({
+      disposition: "REQUIRE_AUTHORITY",
+      reason: "WARDEN_DECISION_EXPIRED",
+    });
+  });
+
+  it("returns non-authoritative transition and River outbox proposals only after authority and evidence", () => {
+    const result = evaluateRegistryGateProposalV1({
+      request,
+      decision: allowDecision,
+      temporalCondition: temporal,
+      evidenceSatisfied: true,
+      evaluatedAt,
+      currentState: "DUE",
+    });
+
+    expect(result.disposition).toBe("READY_TO_PROPOSE");
+    expect(result.transitionProposal).toMatchObject({
+      subjectRef: request.gateEventRef,
+      fromState: "DUE",
+      toState: "EFFECTIVE",
+      wardenDecisionRef: allowDecision.decisionRef,
+      evidenceSetRef: request.evidenceSetRef,
+      requiresExecutionCheckpoint: true,
+    });
+    expect(result.outboxProposal).toMatchObject({
+      eventType: "registry.gate.transition.proposed",
+      aggregateRef: request.gateEventRef,
+      wardenDecisionRef: allowDecision.decisionRef,
+      requiresExecutionCheckpoint: true,
+      payload: {
+        commandType: "GATE_DECLARE",
+        proposedState: "EFFECTIVE",
+        temporalCondition: {
+          conditionType: "DEADLINE_DUE",
+          source: "SENTINEL_CLOCK",
+        },
+      },
+    });
+  });
+});

--- a/modules/synnergyze/registry-provisioning.ts
+++ b/modules/synnergyze/registry-provisioning.ts
@@ -1,0 +1,256 @@
+import type { WardenDecisionV1 } from "../warden/contracts.ts";
+
+export type RegistryCommandTypeV1 =
+  | "PROGRAM_PROVISION"
+  | "SCHEDULE_PROPOSE"
+  | "SCHEDULE_BASELINE_APPROVE"
+  | "SCHEDULE_AMEND"
+  | "GATE_CHECK"
+  | "GATE_DECLARE"
+  | "GATE_HOLD"
+  | "EXCEPTION_REQUEST"
+  | "EXCEPTION_APPROVE"
+  | "EXCEPTION_DENY"
+  | "PACKAGE_INSTALL_REQUEST"
+  | "PACKAGE_ENABLE_REQUEST"
+  | "PACKAGE_SUSPEND_REQUEST"
+  | "PACKAGE_REVOKE_REQUEST";
+
+export interface RegistryCommandEnvelopeV1 {
+  commandRef: string;
+  commandType: RegistryCommandTypeV1;
+  subjectRef: string;
+  actorRef: string;
+  actingCapacityRef: string;
+  representedPrincipalRef?: string;
+  evidenceRefs: readonly string[];
+  correlationId: string;
+  idempotencyKey: string;
+  requestedEffectiveAt?: string;
+}
+
+export interface GateDeclareRequestV1 {
+  envelope: RegistryCommandEnvelopeV1 & { commandType: "GATE_DECLARE" };
+  gateEventRef: string;
+  evidenceSetRef: string;
+}
+
+export type SentinelTemporalConditionTypeV1 =
+  | "TIME_REACHED"
+  | "WINDOW_OPEN"
+  | "WINDOW_CLOSED"
+  | "DEADLINE_DUE"
+  | "DEADLINE_MISSED"
+  | "RECURRENCE_DUE"
+  | "DEPENDENCY_TIME_SATISFIED";
+
+export interface SentinelTemporalConditionV1 {
+  conditionRef: string;
+  conditionType: SentinelTemporalConditionTypeV1;
+  subjectRef: string;
+  observedAt: string;
+  source: "SENTINEL_CLOCK";
+}
+
+export type RegistryGateProposalDispositionV1 =
+  | "REQUIRE_AUTHORITY"
+  | "REQUIRE_EVIDENCE"
+  | "DENIED"
+  | "READY_TO_PROPOSE";
+
+export interface RegistryGateTransitionProposalV1 {
+  subjectType: "GATE_EVENT";
+  subjectRef: string;
+  fromState: "DUE" | "READY" | "HELD" | "PLANNED";
+  toState: "EFFECTIVE";
+  transitionType: "AUTHORITY_DECLARED_GATE";
+  actorRef: string;
+  actingCapacityRef: string;
+  wardenDecisionRef: string;
+  evidenceSetRef: string;
+  correlationId: string;
+  causationRef: string;
+  requiresExecutionCheckpoint: true;
+}
+
+export interface RiverGateOutboxProposalV1 {
+  eventType: "registry.gate.transition.proposed";
+  aggregateType: "GATE_EVENT";
+  aggregateRef: string;
+  correlationId: string;
+  causationRef: string;
+  wardenDecisionRef: string;
+  evidenceSetRef: string;
+  requiresExecutionCheckpoint: true;
+  payload: {
+    commandType: "GATE_DECLARE";
+    proposedState: "EFFECTIVE";
+    temporalCondition?: {
+      conditionType: SentinelTemporalConditionTypeV1;
+      observedAt: string;
+      source: "SENTINEL_CLOCK";
+    };
+  };
+}
+
+export interface RegistryGateProposalResultV1 {
+  disposition: RegistryGateProposalDispositionV1;
+  reason: string;
+  transitionProposal?: RegistryGateTransitionProposalV1;
+  outboxProposal?: RiverGateOutboxProposalV1;
+}
+
+export interface RegistryGateProposalInputV1 {
+  request: GateDeclareRequestV1;
+  decision?: WardenDecisionV1;
+  temporalCondition?: SentinelTemporalConditionV1;
+  evidenceSatisfied: boolean;
+  evaluatedAt: string;
+  currentState?: "DUE" | "READY" | "HELD" | "PLANNED";
+}
+
+function parseInstant(value: string, errorCode: string): number {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) throw new Error(errorCode);
+  return parsed;
+}
+
+function evaluateAuthority(
+  request: GateDeclareRequestV1,
+  decision: WardenDecisionV1 | undefined,
+  evaluatedAt: string,
+): RegistryGateProposalResultV1 | undefined {
+  if (!decision) {
+    return { disposition: "REQUIRE_AUTHORITY", reason: "WARDEN_DECISION_REQUIRED" };
+  }
+
+  if (decision.decision === "DENY") {
+    return { disposition: "DENIED", reason: "WARDEN_DENIED" };
+  }
+
+  if (decision.decision === "ESCALATE") {
+    return { disposition: "REQUIRE_AUTHORITY", reason: "WARDEN_ESCALATION_REQUIRED" };
+  }
+
+  if (decision.requestRef !== request.envelope.commandRef) {
+    return { disposition: "DENIED", reason: "WARDEN_REQUEST_MISMATCH" };
+  }
+  if (decision.action !== "registry.gate.declare") {
+    return { disposition: "DENIED", reason: "WARDEN_ACTION_MISMATCH" };
+  }
+  if (decision.targetRef !== request.gateEventRef) {
+    return { disposition: "DENIED", reason: "WARDEN_TARGET_MISMATCH" };
+  }
+  if (decision.correlationId !== request.envelope.correlationId) {
+    return { disposition: "DENIED", reason: "WARDEN_CORRELATION_MISMATCH" };
+  }
+  if (!decision.validUntil) {
+    return { disposition: "REQUIRE_AUTHORITY", reason: "WARDEN_VALIDITY_REQUIRED" };
+  }
+
+  const decidedAt = parseInstant(decision.decidedAt, "registry_gate_invalid_decision_time");
+  const validUntil = parseInstant(decision.validUntil, "registry_gate_invalid_decision_validity");
+  const evaluated = parseInstant(evaluatedAt, "registry_gate_invalid_evaluation_time");
+  if (validUntil < decidedAt) {
+    return { disposition: "DENIED", reason: "WARDEN_INVALID_VALIDITY_WINDOW" };
+  }
+  if (evaluated < decidedAt) {
+    return { disposition: "DENIED", reason: "WARDEN_DECISION_FROM_FUTURE" };
+  }
+  if (evaluated > validUntil) {
+    return { disposition: "REQUIRE_AUTHORITY", reason: "WARDEN_DECISION_EXPIRED" };
+  }
+
+  return undefined;
+}
+
+/**
+ * Evaluates whether Synnergyze may emit proposals for a governed Registry Gate transition.
+ *
+ * This function does not mutate Registry state, publish a River event, or execute the
+ * transition. Sentinel time is context only. A Warden ALLOW decision is necessary but not
+ * sufficient: mandatory evidence must also be satisfied, and the eventual execution boundary
+ * must perform a fresh Warden execution checkpoint before any authoritative effect.
+ */
+export function evaluateRegistryGateProposalV1(
+  input: RegistryGateProposalInputV1,
+): RegistryGateProposalResultV1 {
+  const { request, decision, temporalCondition, evidenceSatisfied, evaluatedAt } = input;
+
+  if (request.envelope.subjectRef !== request.gateEventRef) {
+    return { disposition: "DENIED", reason: "REGISTRY_SUBJECT_MISMATCH" };
+  }
+
+  if (temporalCondition && temporalCondition.subjectRef !== request.gateEventRef) {
+    return { disposition: "DENIED", reason: "TEMPORAL_FACT_SUBJECT_MISMATCH" };
+  }
+
+  const authorityResult = evaluateAuthority(request, decision, evaluatedAt);
+  if (authorityResult) {
+    if (!decision && temporalCondition) {
+      return {
+        disposition: "REQUIRE_AUTHORITY",
+        reason: "SENTINEL_FACT_PRESENT_BUT_WARDEN_DECISION_REQUIRED",
+      };
+    }
+    return authorityResult;
+  }
+
+  if (!evidenceSatisfied) {
+    return {
+      disposition: "REQUIRE_EVIDENCE",
+      reason: "MANDATORY_GATE_EVIDENCE_NOT_SATISFIED",
+    };
+  }
+
+  const allowedDecision = decision;
+  if (!allowedDecision || allowedDecision.decision !== "ALLOW") {
+    throw new Error("registry_gate_internal_authority_narrowing_failed");
+  }
+
+  const transitionProposal: RegistryGateTransitionProposalV1 = {
+    subjectType: "GATE_EVENT",
+    subjectRef: request.gateEventRef,
+    fromState: input.currentState ?? "DUE",
+    toState: "EFFECTIVE",
+    transitionType: "AUTHORITY_DECLARED_GATE",
+    actorRef: request.envelope.actorRef,
+    actingCapacityRef: request.envelope.actingCapacityRef,
+    wardenDecisionRef: allowedDecision.decisionRef,
+    evidenceSetRef: request.evidenceSetRef,
+    correlationId: request.envelope.correlationId,
+    causationRef: request.envelope.commandRef,
+    requiresExecutionCheckpoint: true,
+  };
+
+  const outboxProposal: RiverGateOutboxProposalV1 = {
+    eventType: "registry.gate.transition.proposed",
+    aggregateType: "GATE_EVENT",
+    aggregateRef: request.gateEventRef,
+    correlationId: request.envelope.correlationId,
+    causationRef: request.envelope.commandRef,
+    wardenDecisionRef: allowedDecision.decisionRef,
+    evidenceSetRef: request.evidenceSetRef,
+    requiresExecutionCheckpoint: true,
+    payload: {
+      commandType: "GATE_DECLARE",
+      proposedState: "EFFECTIVE",
+      ...(temporalCondition
+        ? {
+            temporalCondition: {
+              conditionType: temporalCondition.conditionType,
+              observedAt: temporalCondition.observedAt,
+              source: temporalCondition.source,
+            },
+          }
+        : {}),
+    },
+  };
+
+  return {
+    disposition: "READY_TO_PROPOSE",
+    reason: "WARDEN_ALLOWED_AND_EVIDENCE_SATISFIED",
+    transitionProposal,
+    outboxProposal,
+  };
+}


### PR DESCRIPTION
## Supersedes

Supersedes draft PR #24 without transplanting its stale `src/provisioning` surface.

## Why this replacement is required

Current `genesis` has moved substantially beyond #24. `src/**` is now excluded from the current TypeScript programme, while the current Warden boundary is defined by `modules/warden/contracts.ts` and the controlled-execution checkpoint chain.

## Change

Adds `modules/synnergyze/registry-provisioning.ts` and a focused fail-closed test suite.

The boundary now enforces:

- Sentinel temporal facts are context only and never manufacture authority.
- A current Warden `ALLOW` must bind the same request, action, target and correlation.
- Warden `DENY`, `ESCALATE`, expiry, invalid validity, mismatched target/request/action/correlation, or missing authority fail closed.
- Mandatory evidence remains separately required.
- Successful evaluation returns only `READY_TO_PROPOSE` plus non-authoritative Registry-transition and River-outbox proposals.
- Every successful proposal carries `requiresExecutionCheckpoint: true`; authoritative execution still requires the current Warden execution-checkpoint boundary.
- This code does not mutate Registry state or publish River evidence/events.

## Test matrix

Covers Sentinel-without-authority, Warden deny, Warden escalation, missing evidence, target mismatch, expired authority, and the smallest positive proposal case.

## Boundary

Draft only until exact-head lint, type-check and test workflows are green. No production promotion, Registry mutation, River publication, settlement finality, or live Alpha activation is implied.