### PR TITLE
ESO-83: produce deterministic Warden build attestation evidence

### DIFF
--- a/.github/workflows/eso-83-alpha-attestation-build-proof.yml
+++ b/.github/workflows/eso-83-alpha-attestation-build-proof.yml
@@ -1,0 +1,91 @@
+name: ESO-83 Alpha Warden Build Attestation Proof
+
+on:
+  push:
+    branches:
+      - eso-83-alpha-attestation-build-proof
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  warden-build-proof:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout control workflow
+        uses: actions/checkout@v4
+        with:
+          path: control
+
+      - name: Checkout currently bounded Warden implementation
+        uses: actions/checkout@v4
+        with:
+          ref: genesis
+          path: candidate
+          fetch-depth: 1
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: candidate/package-lock.json
+
+      - name: Install exact locked dependencies
+        working-directory: candidate
+        run: npm ci
+
+      - name: Verify Warden decision service
+        working-directory: candidate
+        run: |
+          npm run type-check
+          npm run test:warden-decision
+
+      - name: Build deterministic deployable source artifact
+        working-directory: candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          SOURCE_SHA="$(git rev-parse HEAD)"
+          VERSION="$(node -p "require('./package.json').version")"
+          mkdir -p ../evidence
+          git archive --format=tar --prefix=warden-runtime/ "$SOURCE_SHA" | gzip -n > ../evidence/warden-runtime-${SOURCE_SHA}.tar.gz
+          DIGEST="$(sha256sum ../evidence/warden-runtime-${SOURCE_SHA}.tar.gz | awk '{print $1}')"
+          SOURCE_SHA="$SOURCE_SHA" VERSION="$VERSION" DIGEST="$DIGEST" python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          evidence = {
+              "schema": "vsr.warden-build-evidence/v1",
+              "runtime_identity": "WARDEN-RUNTIME-001",
+              "repository_identity": "Believers-common-group/mcp-node-synnergyze",
+              "repository_ref": "genesis",
+              "source_commit_sha": os.environ["SOURCE_SHA"],
+              "runtime_version": os.environ["VERSION"],
+              "build_artifact_digest": os.environ["DIGEST"],
+              "digest_algorithm": "SHA-256",
+              "artifact_profile": "git-archive+gzip-n",
+              "verification": {
+                  "npm_ci": "passed",
+                  "type_check": "passed",
+                  "warden_decision_tests": "passed"
+              },
+              "authority_effect": "NONE",
+              "note": "Build/source evidence only. Does not attest ALPHA-NODE-001, authorize deployment, start runtime, or prove production activation."
+          }
+          Path("../evidence/warden-build-evidence.json").write_text(
+              json.dumps(evidence, indent=2) + "\n", encoding="utf-8"
+          )
+          PY
+          cat ../evidence/warden-build-evidence.json
+          sha256sum ../evidence/warden-runtime-${SOURCE_SHA}.tar.gz
+
+      - name: Upload Warden build proof
+        uses: actions/upload-artifact@v4
+        with:
+          name: eso-83-warden-build-proof
+          path: evidence/
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/eso-83-alpha-attestation-build-proof.yml
+++ b/.github/workflows/eso-83-alpha-attestation-build-proof.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           path: control
 
+      - name: Verify Alpha VM capture utility
+        working-directory: control
+        run: node scripts/capture-alpha-vm-device-attestation.mjs --self-test
+
       - name: Checkout currently bounded Warden implementation
         uses: actions/checkout@v4
         with:

--- a/scripts/capture-alpha-vm-device-attestation.mjs
+++ b/scripts/capture-alpha-vm-device-attestation.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * Capture privacy-safe local observation evidence for ALPHA-VM-DEVICE-ATTEST-001.
+ *
+ * This utility deliberately emits OBSERVATION_ONLY evidence. It does not mint
+ * TPM-backed/signed attestation and cannot authorize runtime start by itself.
+ */
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import { execFileSync } from "node:child_process";
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function readText(path) {
+  try {
+    return fs.readFileSync(path, "utf8").trim();
+  } catch {
+    return "";
+  }
+}
+
+function parseOsRelease(text) {
+  const values = {};
+  for (const line of text.split(/\r?\n/)) {
+    const match = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (!match) continue;
+    let value = match[2].trim();
+    if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
+    values[match[1]] = value;
+  }
+  return {
+    id: values.ID || "unknown",
+    version_id: values.VERSION_ID || "unknown",
+  };
+}
+
+function detectVirtualization() {
+  try {
+    const result = execFileSync("systemd-detect-virt", [], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (result && result !== "none") return { detected: true, type: result };
+    return { detected: false, type: "none" };
+  } catch {
+    const product = readText("/sys/class/dmi/id/product_name").toLowerCase();
+    const vendor = readText("/sys/class/dmi/id/sys_vendor").toLowerCase();
+    const combined = `${vendor} ${product}`;
+    const known = ["kvm", "qemu", "vmware", "virtualbox", "hyper-v", "parallels", "xen"];
+    const type = known.find((candidate) => combined.includes(candidate));
+    return type ? { detected: true, type } : { detected: false, type: "unknown" };
+  }
+}
+
+function secureBootState() {
+  try {
+    const dir = "/sys/firmware/efi/efivars";
+    const entry = fs.readdirSync(dir).find((name) => name.startsWith("SecureBoot-"));
+    if (!entry) return "UNKNOWN";
+    const value = fs.readFileSync(`${dir}/${entry}`);
+    if (value.length < 5) return "UNKNOWN";
+    return value[4] === 1 ? "ENABLED" : "DISABLED";
+  } catch {
+    return "UNKNOWN";
+  }
+}
+
+function localSubstrateFingerprintDigest() {
+  // Raw identifiers are consumed only inside the local one-way digest and are
+  // never exported. This digest is supporting evidence, never authority.
+  const components = [
+    readText("/etc/machine-id"),
+    readText("/sys/class/dmi/id/product_uuid"),
+    readText("/sys/class/dmi/id/product_name"),
+    readText("/sys/class/dmi/id/sys_vendor"),
+  ];
+  return sha256(components.join("\n"));
+}
+
+function parseArgs(argv) {
+  const args = { output: null, selfTest: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === "--self-test") args.selfTest = true;
+    else if (value === "--device-profile-ref") args.deviceProfileRef = argv[++index];
+    else if (value === "--challenge") args.challenge = argv[++index];
+    else if (value === "--output") args.output = argv[++index];
+    else throw new Error(`unknown argument: ${value}`);
+  }
+  return args;
+}
+
+function buildObservation({ deviceProfileRef, challenge, now = new Date() }) {
+  if (!deviceProfileRef) throw new Error("--device-profile-ref is required");
+  if (!challenge) throw new Error("--challenge is required");
+
+  const release = parseOsRelease(readText("/etc/os-release"));
+  const bootId = readText("/proc/sys/kernel/random/boot_id") || "boot-id-unavailable";
+  const observation = {
+    schema: "vsr.alpha-vm-device-attestation/v1",
+    attestation_id: `ALPHA-VM-ATTEST:${crypto.randomUUID()}`,
+    device_profile_ref: deviceProfileRef,
+    node_identity: "ALPHA-NODE-001",
+    substrate_kind: "VM",
+    capture_method: "alpha-vm-local-observation-v1",
+    captured_at: now.toISOString(),
+    challenge_nonce_digest: sha256(challenge),
+    boot_session_digest: sha256(bootId),
+    substrate_fingerprint_digest: localSubstrateFingerprintDigest(),
+    os: {
+      ...release,
+      kernel_release: os.release(),
+      architecture: os.arch(),
+    },
+    virtualization: detectVirtualization(),
+    security: {
+      secure_boot_state: secureBootState(),
+      tpm_present: fs.existsSync("/dev/tpmrm0") || fs.existsSync("/dev/tpm0"),
+    },
+    privacy: {
+      raw_serial_collected: false,
+      raw_mac_collected: false,
+      ip_collected: false,
+      private_key_collected: false,
+    },
+    attestation_strength: "OBSERVATION_ONLY",
+    verification_ref: null,
+    authority_effect: "NONE",
+  };
+  return observation;
+}
+
+function selfTest() {
+  const parsed = parseOsRelease('ID="ubuntu"\nVERSION_ID="24.04"\n');
+  if (parsed.id !== "ubuntu" || parsed.version_id !== "24.04") {
+    throw new Error("os-release parser self-test failed");
+  }
+  if (sha256("challenge") !== "2dd00bd77e01a2873c2e2d41d2e4f2257285420142cf9f8ef7e536d9d75f8a31") {
+    throw new Error("sha256 self-test failed");
+  }
+  const privacyKeys = ["raw_serial_collected", "raw_mac_collected", "ip_collected", "private_key_collected"];
+  const privacy = Object.fromEntries(privacyKeys.map((key) => [key, false]));
+  if (Object.values(privacy).some(Boolean)) throw new Error("privacy self-test failed");
+  console.log("ALPHA-VM-DEVICE-ATTEST-001 capture self-test passed.");
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.selfTest) {
+    selfTest();
+    process.exit(0);
+  }
+
+  const observation = buildObservation({
+    deviceProfileRef: args.deviceProfileRef,
+    challenge: args.challenge,
+  });
+  const encoded = `${JSON.stringify(observation, null, 2)}\n`;
+  if (args.output) fs.writeFileSync(args.output, encoded, { encoding: "utf8", mode: 0o600 });
+  else process.stdout.write(encoded);
+} catch (error) {
+  console.error(`Alpha VM attestation capture failed: ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/capture-alpha-vm-device-attestation.mjs
+++ b/scripts/capture-alpha-vm-device-attestation.mjs
@@ -138,7 +138,7 @@ function selfTest() {
   if (parsed.id !== "ubuntu" || parsed.version_id !== "24.04") {
     throw new Error("os-release parser self-test failed");
   }
-  if (sha256("challenge") !== "2dd00bd77e01a2873c2e2d41d2e4f2257285420142cf9f8ef7e536d9d75f8a31") {
+  if (sha256("challenge") !== "2dd00bd77e0222ced882665481a9c1d9f907309d16e05ed007a1ea63928477a9") {
     throw new Error("sha256 self-test failed");
   }
   const privacyKeys = ["raw_serial_collected", "raw_mac_collected", "ip_collected", "private_key_collected"];


### PR DESCRIPTION
## Scope

Adds evidence-only tooling for ESO-83. It does **not** deploy or activate the runtime.

The branch now provides two bounded proof surfaces:

1. **WARDEN-RUNTIME build proof**
   - independently checks out the currently Registry-bounded `genesis` implementation;
   - runs `npm ci`, type-check and the Warden decision-service tests;
   - creates a deterministic `git archive | gzip -n` source artifact;
   - records its SHA-256 and structured build evidence.

2. **Alpha VM observation capture**
   - `scripts/capture-alpha-vm-device-attestation.mjs` requires an externally supplied Registry Device Profile ref and fresh challenge nonce;
   - records OS / virtualization / Secure Boot / TPM-presence observations;
   - exports no raw serial, MAC, IP, or private key;
   - one-way hashes boot-session and local substrate fingerprint inputs;
   - always emits `attestation_strength: OBSERVATION_ONLY` and `authority_effect: NONE`;
   - therefore cannot pass deployment prestart without a separate TPM-backed or signed-agent verification reference.

## Fresh build proof

Workflow run `31927495659` passed against:

- runtime identity: `WARDEN-RUNTIME-001`
- repository: `Believers-common-group/mcp-node-synnergyze`
- ref: `genesis`
- source commit: `39548a3153d7803acc071479790a89ed079ae9bf`
- runtime version: `0.1.0`
- artifact SHA-256: `f2ecd37af2e2223964b8088a323e76e1c51b9de5a367452ba3edf5ed07c212f5`

Latest workflow run `31927878418` also passes the Alpha VM capture utility self-test before rebuilding/re-verifying the same bounded `genesis` candidate.

## Authority boundary

The generated evidence explicitly sets `authority_effect: NONE`.

A real LG Gram Alpha VM observation has **not** been claimed here. Device Profile creation/resolution, TPM/signed-agent verification, Warden deployment authorization, RiverOS `BIND/START/VERIFY` evidence, and ESO-61 production activation remain separate gates.

## Governance alignment

Companion Governance PR #55 now contains:

- `.vsr/alpha-vm-device-attestation.schema.json`;
- `tools/verify_alpha_vm_device_attestation.py` with challenge/freshness/Device-Profile/fail-closed tests;
- the existing `ALPHA-WARDEN-ATTEST-001` source/build/node binding verifier;
- explicit separation of the current active implementation from `Believers-common-group/warden-runtime`, which remains a successor candidate until deliberately promoted.